### PR TITLE
IS-76 Work-around for OpenSAML bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.swedenconnect.opensaml</groupId>
   <artifactId>opensaml-addons</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1</version>
+  <version>2.1.2-SNAPSHOT</version>
 
   <name>Sweden Connect :: OpenSAML 5.X utility extensions</name>
   <description>OpenSAML 5.X utility extension library</description>
@@ -44,11 +44,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
 
-    <opensaml.version>5.1.2</opensaml.version>
+    <opensaml.version>5.1.3</opensaml.version>
     <shib.support.version>9.1.2</shib.support.version>
-    <slf4j.version>2.0.13</slf4j.version>
-    <jackson.version>2.17.1</jackson.version>
-    <bc.version>1.78.1</bc.version>
+    <slf4j.version>2.0.16</slf4j.version>
+    <jackson.version>2.18.1</jackson.version>
+    <bc.version>1.79</bc.version>
   </properties>
 
   <repositories>
@@ -88,13 +88,13 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.2.4</version>
+        <version>5.3.1</version>
       </dependency>
 
       <dependency>
@@ -136,7 +136,21 @@
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.5</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.17.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml-bom</artifactId>
+        <version>${opensaml.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>
@@ -163,12 +177,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.opensaml</groupId>
-      <artifactId>opensaml-storage-api</artifactId>
-      <version>${opensaml.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <version>6.1.0</version>
@@ -178,28 +186,27 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
     </dependency>
 
     <!-- For testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.2</version>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.10.2</version>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.12.0</version>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -213,7 +220,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>11.0.21</version>
+      <version>12.0.15</version>
       <!-- <version>9.4.18.v20190429</version> -->
       <scope>test</scope>
       <exclusions>
@@ -228,7 +235,7 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <!-- <version>9.4.18.v20190429</version> -->
-      <version>11.0.21</version>
+      <version>12.0.15</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -241,7 +248,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.17.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -261,7 +268,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.13.0</version>
         <configuration>
           <release>${java.version}</release>
         </configuration>
@@ -270,25 +277,25 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.5.0</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.2</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -307,7 +314,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.10.1</version>
         <configuration>
           <doctitle>OpenSAML 5.x utility extensions - ${project.version}</doctitle>
           <windowtitle>OpenSAML 5.x utility extensions - ${project.version}</windowtitle>
@@ -357,7 +364,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -375,7 +382,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.2.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -390,7 +397,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>

--- a/src/main/java/se/swedenconnect/opensaml/common/LibraryVersion.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/LibraryVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ public final class LibraryVersion {
 
   private static final int MAJOR = 2;
   private static final int MINOR = 1;
-  private static final int PATCH = 1;
+  private static final int PATCH = 2;
 
   /**
    * Global serialization value for library classes.
    */
-  public static final long SERIAL_VERSION_UID = getVersion().hashCode();
+  public static final long SERIAL_VERSION_UID = (MAJOR + "." + MINOR).hashCode();
 
   /**
    * Gets the version string.

--- a/src/main/java/se/swedenconnect/opensaml/common/builder/AbstractSAMLObjectBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/builder/AbstractSAMLObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package se.swedenconnect.opensaml.common.builder;
 
-import java.io.InputStream;
-
-import javax.xml.namespace.QName;
-
+import net.shibboleth.shared.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.XMLRuntimeException;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
@@ -27,19 +24,19 @@ import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.w3c.dom.Element;
 
-import net.shibboleth.shared.xml.XMLParserException;
+import javax.xml.namespace.QName;
+import java.io.InputStream;
 
 /**
  * Abstract base class for the builder pattern.
  *
- * @author Martin Lindström (martin@idsec.se)
- *
  * @param <T> the type
+ * @author Martin Lindström (martin@idsec.se)
  */
 public abstract class AbstractSAMLObjectBuilder<T extends XMLObject> implements SAMLObjectBuilder<T> {
 
   /** The object that is being built. */
-  private T object;
+  private final T object;
 
   /**
    * Constructor setting up the object to build.
@@ -100,7 +97,7 @@ public abstract class AbstractSAMLObjectBuilder<T extends XMLObject> implements 
 
   /**
    * The default implementation of this method assumes that the object has been built during assignment of its
-   * attributes and elements so it simply returns the object.
+   * attributes and elements, so it simply returns the object.
    * <p>
    * Implementations that need to perform additional processing during the build step should override this method.
    * </p>
@@ -135,7 +132,7 @@ public abstract class AbstractSAMLObjectBuilder<T extends XMLObject> implements 
     try {
       return (QName) this.getObjectType().getDeclaredField("DEFAULT_ELEMENT_NAME").get(null);
     }
-    catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+    catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
       throw new XMLRuntimeException(e);
     }
   }

--- a/src/main/java/se/swedenconnect/opensaml/common/builder/SAMLObjectBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/builder/SAMLObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/common/builder/SAMLObjectBuilderRuntimeException.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/builder/SAMLObjectBuilderRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package se.swedenconnect.opensaml.common.builder;
 
 import se.swedenconnect.opensaml.common.LibraryVersion;
 
+import java.io.Serial;
+
 /**
  * Runtime exception class for errors when using builders.
  *
@@ -25,6 +27,7 @@ import se.swedenconnect.opensaml.common.LibraryVersion;
 public class SAMLObjectBuilderRuntimeException extends RuntimeException {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/common/builder/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/builder/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Package containing base interfaces and classes for the builder pattern where SAMLObjects are built by cascading
  * calls.

--- a/src/main/java/se/swedenconnect/opensaml/common/utils/LocalizedString.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/utils/LocalizedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,8 @@ public class LocalizedString {
    * @param source the string to parse
    */
   public LocalizedString(final String source) {
-    String _source = source.trim();
-    int i = _source.indexOf('-');
+    final String _source = source.trim();
+    final int i = _source.indexOf('-');
     if (i <= 0 || i > 3) {
       throw new IllegalArgumentException("Bad format on localized string, expected <language code>-String");
     }
@@ -144,8 +144,7 @@ public class LocalizedString {
     if (obj == this) {
       return true;
     }
-    if (obj instanceof LocalizedString) {
-      LocalizedString otherLString = (LocalizedString) obj;
+    if (obj instanceof final LocalizedString otherLString) {
       return Objects.equal(this.localizedString, otherLString.getLocalString())
           && Objects.equal(this.getLanguage(), otherLString.getLanguage());
     }

--- a/src/main/java/se/swedenconnect/opensaml/common/utils/SamlLog.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/utils/SamlLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class SamlLog {
     try {
       return toString(object);
     }
-    catch (Exception e) {
+    catch (final Exception e) {
       return "";
     }
   }

--- a/src/main/java/se/swedenconnect/opensaml/common/utils/SerializableOpenSamlObject.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/utils/SerializableOpenSamlObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,33 +15,33 @@
  */
 package se.swedenconnect.opensaml.common.utils;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.util.Objects;
-
+import net.shibboleth.shared.xml.SerializeSupport;
+import net.shibboleth.shared.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
-
-import net.shibboleth.shared.xml.SerializeSupport;
-import net.shibboleth.shared.xml.XMLParserException;
 import se.swedenconnect.opensaml.common.LibraryVersion;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Utility class for storing OpenSAML objects in a serializable manner.
  *
  * @param <T> the type of object being stored
- *
  * @author Martin Lindström
  */
 public class SerializableOpenSamlObject<T extends XMLObject> implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /** The object that we wrap. */
@@ -65,8 +65,9 @@ public class SerializableOpenSamlObject<T extends XMLObject> implements Serializ
     return this.object;
   }
 
+  @Serial
   private void writeObject(final ObjectOutputStream out) throws IOException {
-    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+    try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
       SerializeSupport.writeNode(XMLObjectSupport.marshall(this.object), bos);
       out.writeObject(bos.toByteArray());
     }
@@ -75,10 +76,10 @@ public class SerializableOpenSamlObject<T extends XMLObject> implements Serializ
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @Serial
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     final byte[] bytes = (byte[]) in.readObject();
-    try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes)) {
+    try (final ByteArrayInputStream bis = new ByteArrayInputStream(bytes)) {
       this.object =
           (T) XMLObjectSupport.unmarshallFromInputStream(XMLObjectProviderRegistrySupport.getParserPool(), bis);
     }

--- a/src/main/java/se/swedenconnect/opensaml/common/utils/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/utils/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Utility classes.
  */

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/AbstractObjectValidator.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/AbstractObjectValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
  */
 package se.swedenconnect.opensaml.common.validation;
 
-import java.time.Duration;
-import java.time.Instant;
-
+import net.shibboleth.shared.primitive.DeprecationSupport;
+import net.shibboleth.shared.primitive.DeprecationSupport.ObjectType;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.assertion.ValidationContext;
 import org.opensaml.saml.saml2.assertion.SAML20AssertionValidator;
 import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
 
-import net.shibboleth.shared.primitive.DeprecationSupport;
-import net.shibboleth.shared.primitive.DeprecationSupport.ObjectType;
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Abstract base class for {@link ObjectValidator}.
@@ -60,7 +59,7 @@ public abstract class AbstractObjectValidator<T extends XMLObject> implements Ob
    */
   public static boolean isStrictValidation(final ValidationContext context) {
     final Boolean strict = (Boolean) context.getStaticParameters().get(CoreValidatorParameters.STRICT_VALIDATION);
-    return strict != null ? strict.booleanValue() : false;
+    return strict != null && strict;
   }
 
   /**
@@ -74,13 +73,13 @@ public abstract class AbstractObjectValidator<T extends XMLObject> implements Ob
   public static Duration getAllowedClockSkew(final ValidationContext context) {
     final Object object = context.getStaticParameters().get(SAML2AssertionValidationParameters.CLOCK_SKEW);
     if (object != null) {
-      if (Duration.class.isInstance(object)) {
-        return Duration.class.cast(object);
+      if (object instanceof Duration) {
+        return (Duration) object;
       }
-      else if (Long.class.isInstance(object)) {
+      else if (object instanceof Long) {
         DeprecationSupport.warn(ObjectType.CONFIGURATION, SAML2AssertionValidationParameters.CLOCK_SKEW, null,
             Duration.class.getName());
-        return Duration.ofMillis(Long.class.cast(object));
+        return Duration.ofMillis((Long) object);
       }
     }
     return SAML20AssertionValidator.DEFAULT_CLOCK_SKEW;
@@ -97,13 +96,13 @@ public abstract class AbstractObjectValidator<T extends XMLObject> implements Ob
   public static Duration getMaxAgeReceivedMessage(final ValidationContext context) {
     final Object object = context.getStaticParameters().get(CoreValidatorParameters.MAX_AGE_MESSAGE);
     if (object != null) {
-      if (Duration.class.isInstance(object)) {
-        return Duration.class.cast(object);
+      if (object instanceof Duration) {
+        return (Duration) object;
       }
-      else if (Long.class.isInstance(object)) {
+      else if (object instanceof Long) {
         DeprecationSupport.warn(ObjectType.CONFIGURATION, CoreValidatorParameters.MAX_AGE_MESSAGE, null,
             Duration.class.getName());
-        return Duration.ofMillis(Long.class.cast(object));
+        return Duration.ofMillis((Long) object);
       }
     }
     return DEFAULT_MAX_AGE_RECEIVED_MESSAGE;
@@ -119,13 +118,13 @@ public abstract class AbstractObjectValidator<T extends XMLObject> implements Ob
   public static Instant getReceiveInstant(final ValidationContext context) {
     final Object object = context.getStaticParameters().get(CoreValidatorParameters.RECEIVE_INSTANT);
     if (object != null) {
-      if (Instant.class.isInstance(object)) {
-        return Instant.class.cast(object);
+      if (object instanceof Instant) {
+        return (Instant) object;
       }
-      else if (Long.class.isInstance(object)) {
+      else if (object instanceof Long) {
         DeprecationSupport.warn(ObjectType.CONFIGURATION, CoreValidatorParameters.RECEIVE_INSTANT, null,
             Duration.class.getName());
-        return Instant.ofEpochMilli(Long.class.cast(object));
+        return Instant.ofEpochMilli((Long) object);
       }
     }
     return Instant.now();

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/AbstractValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/AbstractValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,14 @@
  */
 package se.swedenconnect.opensaml.common.validation;
 
+import net.shibboleth.shared.resolver.CriteriaSet;
+import org.opensaml.saml.common.assertion.ValidationContext;
+import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.opensaml.saml.common.assertion.ValidationContext;
-import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
-
-import net.shibboleth.shared.resolver.CriteriaSet;
 
 /**
  * Abstract base class for building the {@link ValidationContext} object using a builder pattern. These settings are
@@ -35,10 +34,10 @@ public abstract class AbstractValidationParametersBuilder<T extends AbstractVali
     ValidationParametersBuilder {
 
   /** The static parameters. */
-  private Map<String, Object> staticParameters = new HashMap<>();
+  private final Map<String, Object> staticParameters = new HashMap<>();
 
   /** The dynamic parameters. */
-  private Map<String, Object> dynamicParameters = new HashMap<>();
+  private final Map<String, Object> dynamicParameters = new HashMap<>();
 
   /** {@inheritDoc} */
   @Override
@@ -128,9 +127,9 @@ public abstract class AbstractValidationParametersBuilder<T extends AbstractVali
   }
 
   /**
-   * Sets the receive instant (i.e., when a message being validated was received).
+   * Sets the reception instant (i.e., when a message being validated was received).
    *
-   * @param instant the receive instant
+   * @param instant the reception instant
    * @return the builder
    */
   public T receiveInstant(final Instant instant) {
@@ -139,9 +138,9 @@ public abstract class AbstractValidationParametersBuilder<T extends AbstractVali
   }
 
   /**
-   * Sets the receive instant (i.e., when a message being validated was received).
+   * Sets the reception instant (i.e., when a message being validated was received).
    *
-   * @param instant the receive instant
+   * @param instant the reception instant
    * @return the builder
    */
   public T receiveInstant(final long instant) {
@@ -175,7 +174,7 @@ public abstract class AbstractValidationParametersBuilder<T extends AbstractVali
   /**
    * Returns 'this' object.
    *
-   * @return this object (the concrete builder}
+   * @return this object (the concrete builder)
    */
   protected abstract T getThis();
 

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/CoreValidatorParameters.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/CoreValidatorParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class CoreValidatorParameters {
   public static final String STRICT_VALIDATION = STD_PREFIX + ".StrictValidation";
 
   /**
-   * Carries a String that holds the entityID of the expected issuer of a element.
+   * Carries a String that holds the entityID of the expected issuer of an element.
    */
   public static final String EXPECTED_ISSUER = STD_PREFIX + ".ExpectedIssuer";
 

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/ObjectValidator.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/ObjectValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/ValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/ValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/ValidationSupport.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/ValidationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package se.swedenconnect.opensaml.common.validation;
 
 import org.opensaml.saml.common.assertion.ValidationResult;
+import se.swedenconnect.opensaml.common.LibraryVersion;
+
+import java.io.Serial;
 
 /**
  * Support methods and functions for validator implementations.
@@ -32,10 +35,10 @@ public class ValidationSupport {
    * Checks if the result is VALID. If not a {@code ValidationResultException} is thrown.
    *
    * @param result the result to check
-   * @throws ValidationResultException for non VALID results
+   * @throws ValidationResultException for non-VALID results
    */
   public static void check(final ValidationResult result) throws ValidationResultException {
-    if (!ValidationResult.VALID.equals(result)) {
+    if (ValidationResult.VALID != result) {
       throw new ValidationResultException(result);
     }
   }
@@ -46,10 +49,11 @@ public class ValidationSupport {
   public static class ValidationResultException extends Exception {
 
     /** For serializing. */
-    private static final long serialVersionUID = -39188491121249365L;
+    @Serial
+    private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
     /** The validation result. */
-    private ValidationResult result;
+    private final ValidationResult result;
 
     /**
      * Constructor.
@@ -57,7 +61,7 @@ public class ValidationSupport {
      * @param result the validation result - must not be {@link ValidationResult#VALID}
      */
     public ValidationResultException(final ValidationResult result) {
-      if (ValidationResult.VALID.equals(result)) {
+      if (ValidationResult.VALID == result) {
         throw new IllegalArgumentException("Result is valid - can not throw ValidationResultException");
       }
       if (result == null) {

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/ValidatorException.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/ValidatorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 package se.swedenconnect.opensaml.common.validation;
 
 import org.opensaml.saml.common.assertion.ValidationContext;
-
 import se.swedenconnect.opensaml.common.LibraryVersion;
+
+import java.io.Serial;
 
 /**
  * Generic exception class for validator errors.
@@ -27,6 +28,7 @@ import se.swedenconnect.opensaml.common.LibraryVersion;
 public class ValidatorException extends Exception {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/common/validation/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/common/validation/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes for validation of XML and SAML objects.
  */

--- a/src/main/java/se/swedenconnect/opensaml/config/XMLObjectProviderInitializer.java
+++ b/src/main/java/se/swedenconnect/opensaml/config/XMLObjectProviderInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package se.swedenconnect.opensaml.config;
 
+import jakarta.annotation.Nonnull;
 import org.opensaml.core.xml.config.AbstractXMLObjectProviderInitializer;
 
 /**
@@ -25,16 +26,17 @@ import org.opensaml.core.xml.config.AbstractXMLObjectProviderInitializer;
 public class XMLObjectProviderInitializer extends AbstractXMLObjectProviderInitializer {
 
   /** Config resources. */
-  private static String[] configs = {
+  private static final String[] configs = {
       "/shib-scope-config.xml"
   };
 
   /** {@inheritDoc} */
   @Override
+  @Nonnull
   protected String[] getConfigResources() {
     try {
       // If the Shibboleth implementation of the Scope element can be found
-      // in the classpath it means that the Shibboleth version will be loaded
+      // in the classpath it means that the Shibboleth version will be loaded,
       // and we don't have to register ours.
       //
       Class.forName("net.shibboleth.idp.saml.xmlobject.impl.ScopeImpl", false, this.getClass().getClassLoader());

--- a/src/main/java/se/swedenconnect/opensaml/config/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/config/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Contains initializing interfaces and classes and support classes for working with OpenSAML objects.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AbstractAssertionValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AbstractAssertionValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,24 @@
  */
 package se.swedenconnect.opensaml.saml2.assertion.validation;
 
+import org.opensaml.saml.common.assertion.ValidationContext;
+import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.swedenconnect.opensaml.common.validation.CoreValidatorParameters;
+import se.swedenconnect.opensaml.saml2.response.validation.AbstractResponseValidationParametersBuilder;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.opensaml.saml.common.assertion.ValidationContext;
-import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import se.swedenconnect.opensaml.common.validation.CoreValidatorParameters;
-import se.swedenconnect.opensaml.saml2.response.validation.AbstractResponseValidationParametersBuilder;
 
 /**
  * Abstract builder class for building the {@link ValidationContext} object for use as validation input to the
@@ -45,11 +45,10 @@ import se.swedenconnect.opensaml.saml2.response.validation.AbstractResponseValid
  * @author Martin Lindström (martin@idsec.se)
  */
 public abstract class AbstractAssertionValidationParametersBuilder<T extends AbstractAssertionValidationParametersBuilder<T>>
-    extends
-    AbstractResponseValidationParametersBuilder<T> {
+    extends AbstractResponseValidationParametersBuilder<T> {
 
   /** Logging instance. */
-  private final Logger log = LoggerFactory.getLogger(AbstractAssertionValidationParametersBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(AbstractAssertionValidationParametersBuilder.class);
 
   /**
    * Adds default settings before invoking the super implementation.
@@ -90,10 +89,8 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
    */
   public T validRecipients(final String... recipients) {
     if (recipients != null) {
-      Set<String> set = new HashSet<>();
-      for (String r : recipients) {
-        set.add(r);
-      }
+      final Set<String> set = new HashSet<>();
+      Collections.addAll(set, recipients);
       this.staticParameter(SAML2AssertionValidationParameters.SC_RECIPIENT_REQUIRED, Boolean.TRUE);
       return this.staticParameter(SAML2AssertionValidationParameters.SC_VALID_RECIPIENTS, set);
     }
@@ -113,10 +110,8 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
    */
   public T validAddresses(final InetAddress... addresses) {
     if (addresses != null) {
-      Set<InetAddress> set = new HashSet<>();
-      for (InetAddress a : addresses) {
-        set.add(a);
-      }
+      final Set<InetAddress> set = new HashSet<>();
+      Collections.addAll(set, addresses);
       if (!set.isEmpty()) {
         this.staticParameter(SAML2AssertionValidationParameters.SC_VALID_ADDRESSES, set);
         this.staticParameter(SAML2AssertionValidationParameters.STMT_AUTHN_VALID_ADDRESSES, set);
@@ -135,13 +130,13 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
     if (addresses == null) {
       return this.getThis();
     }
-    List<InetAddress> _addresses = new ArrayList<>();
-    for (String a : addresses) {
+    final List<InetAddress> _addresses = new ArrayList<>();
+    for (final String a : addresses) {
       try {
         _addresses.add(InetAddress.getByName(a));
       }
-      catch (UnknownHostException e) {
-        log.error("Invalid IP address - " + a, e);
+      catch (final UnknownHostException e) {
+        log.error("Invalid IP address - {}", a, e);
         return this.getThis();
       }
     }
@@ -149,11 +144,11 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
   }
 
   public T subjectConfirmationCheckAddess(final boolean flag) {
-    return this.staticParameter(SAML2AssertionValidationParameters.SC_CHECK_ADDRESS, Boolean.valueOf(flag));
+    return this.staticParameter(SAML2AssertionValidationParameters.SC_CHECK_ADDRESS, flag);
   }
 
   public T subjectLocalityCheckAddress(final boolean flag) {
-    return this.staticParameter(SAML2AssertionValidationParameters.STMT_AUTHN_CHECK_ADDRESS, Boolean.valueOf(flag));
+    return this.staticParameter(SAML2AssertionValidationParameters.STMT_AUTHN_CHECK_ADDRESS, flag);
   }
 
   /**
@@ -164,10 +159,8 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
    */
   public T validAudiences(final String... audiences) {
     if (audiences != null) {
-      Set<String> set = new HashSet<>();
-      for (String a : audiences) {
-        set.add(a);
-      }
+      final Set<String> set = new HashSet<>();
+      Collections.addAll(set, audiences);
       return this.staticParameter(SAML2AssertionValidationParameters.COND_VALID_AUDIENCES, set);
     }
     else {
@@ -206,7 +199,7 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
   }
 
   /**
-   * Assigns the maximum session time that we, as a SP, can accept when receiving assertions based on older
+   * Assigns the maximum session time that we, as an SP, can accept when receiving assertions based on older
    * authentications (SSO).
    *
    * @param duration milliseconds
@@ -217,7 +210,7 @@ public abstract class AbstractAssertionValidationParametersBuilder<T extends Abs
   }
 
   /**
-   * Assigns the maximum session time that we, as a SP, can accept when receiving assertions based on older
+   * Assigns the maximum session time that we, as an SP, can accept when receiving assertions based on older
    * authentications (SSO).
    *
    * @param duration max session time

--- a/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AbstractAttributeStatementValidator.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AbstractAttributeStatementValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package se.swedenconnect.opensaml.saml2.assertion.validation;
 
-import java.util.Collections;
-import java.util.List;
-
-import javax.xml.namespace.QName;
-
+import jakarta.annotation.Nonnull;
 import org.opensaml.saml.common.assertion.AssertionValidationException;
 import org.opensaml.saml.common.assertion.ValidationContext;
 import org.opensaml.saml.common.assertion.ValidationResult;
@@ -28,6 +24,10 @@ import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
 import org.opensaml.saml.saml2.core.Statement;
+
+import javax.xml.namespace.QName;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Abstract validator for {@link AttributeStatement}s.
@@ -38,6 +38,7 @@ public abstract class AbstractAttributeStatementValidator implements StatementVa
 
   /** {@inheritDoc} */
   @Override
+  @Nonnull
   public QName getServicedStatement() {
     return AttributeStatement.DEFAULT_ELEMENT_NAME;
   }
@@ -46,12 +47,12 @@ public abstract class AbstractAttributeStatementValidator implements StatementVa
    * Validates that all required attributes were received in the {@code AttributeStatement}.
    */
   @Override
-  public ValidationResult validate(final Statement statement, final Assertion assertion,
-      final ValidationContext context)
+  @Nonnull
+  public ValidationResult validate(@Nonnull final Statement statement, @Nonnull final Assertion assertion,
+      @Nonnull final ValidationContext context)
       throws AssertionValidationException {
 
-    if (statement instanceof AttributeStatement) {
-      final AttributeStatement attributeStatement = (AttributeStatement) statement;
+    if (statement instanceof final AttributeStatement attributeStatement) {
       final List<Attribute> list =
           attributeStatement.getAttributes() != null ? attributeStatement.getAttributes() : Collections.emptyList();
       return this.validateRequiredAttributes(list, attributeStatement, assertion, context);

--- a/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AssertionValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/AssertionValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/assertion/validation/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes for validation of SAML Assertions.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,7 @@
  */
 package se.swedenconnect.opensaml.saml2.attribute;
 
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.xml.namespace.QName;
-
+import net.shibboleth.shared.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.XMLRuntimeException;
 import org.opensaml.core.xml.io.MarshallingException;
@@ -29,9 +24,12 @@ import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeValue;
-
-import net.shibboleth.shared.xml.XMLParserException;
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
+
+import javax.xml.namespace.QName;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implements the build pattern to create {@link Attribute} objects.
@@ -105,7 +103,8 @@ public class AttributeBuilder extends AbstractSAMLObjectBuilder<Attribute> {
   }
 
   /**
-   * Static utility method that creates a {@code AttributeBuilder} given a template attribute read from an input stream.
+   * Static utility method that creates a {@code AttributeBuilder} given a template attribute read from an input
+   * stream.
    *
    * @param resource the attribute template
    * @return an attribute builder
@@ -179,18 +178,17 @@ public class AttributeBuilder extends AbstractSAMLObjectBuilder<Attribute> {
   }
 
   /**
-   * @see #value(String...)
-   *
    * @param values the string value(s) to add
    * @return the builder
+   * @see #value(String...)
    */
   public AttributeBuilder value(final List<String> values) {
     if (values == null) {
       this.object().getAttributeValues().clear();
       return this;
     }
-    for (String s : values) {
-      XSString sv = createValueObject(XSString.TYPE_NAME, XSString.class);
+    for (final String s : values) {
+      final XSString sv = createValueObject(XSString.TYPE_NAME, XSString.class);
       sv.setValue(s);
       this.object().getAttributeValues().add(sv);
     }
@@ -228,10 +226,10 @@ public class AttributeBuilder extends AbstractSAMLObjectBuilder<Attribute> {
    */
   public static <T extends XMLObject> T createValueObject(final Class<T> clazz) {
     try {
-      QName schemaType = (QName) clazz.getDeclaredField("TYPE_NAME").get(null);
+      final QName schemaType = (QName) clazz.getDeclaredField("TYPE_NAME").get(null);
       return createValueObject(schemaType, clazz);
     }
-    catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+    catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
       throw new XMLRuntimeException(e);
     }
   }
@@ -249,7 +247,7 @@ public class AttributeBuilder extends AbstractSAMLObjectBuilder<Attribute> {
    *
    * @param <T> the type
    * @param schemaType the schema type that should be assigned to the attribute value, i.e.,
-   *          {@code xsi:type="ns:ValueType"}
+   *     {@code xsi:type="ns:ValueType"}
    * @param clazz the type of the attribute value
    * @return the attribute value
    * @see #createValueObject(Class)

--- a/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeConstants.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,22 +26,25 @@ public class AttributeConstants {
    * The attribute name for the assurance certification attribute stored as an attribute in the entity attributes
    * extension.
    */
-  public static final String ASSURANCE_CERTIFICATION_ATTRIBUTE_NAME = "urn:oasis:names:tc:SAML:attribute:assurance-certification";
+  public static final String ASSURANCE_CERTIFICATION_ATTRIBUTE_NAME =
+      "urn:oasis:names:tc:SAML:attribute:assurance-certification";
 
   /**
    * The attribute template for the assurance certification attribute stored as an attribute in the entity attributes
    * extension.
    */
   public static final AttributeTemplate ASSURANCE_CERTIFICATION_ATTRIBUTE_TEMPLATE = new AttributeTemplate(
-    ASSURANCE_CERTIFICATION_ATTRIBUTE_NAME, null);
+      ASSURANCE_CERTIFICATION_ATTRIBUTE_NAME, null);
 
   /** The attribute name for the entity category attribute stored as an attribute in the entity attributes extension. */
   public static final String ENTITY_CATEGORY_ATTRIBUTE_NAME = "http://macedir.org/entity-category";
 
   /**
-   * The attribute template for the entity category attribute stored as an attribute in the entity attributes extension.
+   * The attribute template for the entity category attribute stored as an attribute in the entity attributes
+   * extension.
    */
-  public static final AttributeTemplate ENTITY_CATEGORY_TEMPLATE = new AttributeTemplate(ENTITY_CATEGORY_ATTRIBUTE_NAME, null);
+  public static final AttributeTemplate ENTITY_CATEGORY_TEMPLATE =
+      new AttributeTemplate(ENTITY_CATEGORY_ATTRIBUTE_NAME, null);
 
   // Hidden constructor.
   private AttributeConstants() {

--- a/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeTemplate.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 package se.swedenconnect.opensaml.saml2.attribute;
 
+import org.opensaml.saml.saml2.core.Attribute;
+import se.swedenconnect.opensaml.common.LibraryVersion;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Optional;
-
-import org.opensaml.saml.saml2.core.Attribute;
 
 /**
  * An attribute template is a template of a SAML attribute, i.e., it represents the name, friendly name and name format
@@ -31,23 +33,24 @@ import org.opensaml.saml.saml2.core.Attribute;
  */
 public class AttributeTemplate implements Serializable {
 
-  private static final long serialVersionUID = 1903081114009014914L;
+  @Serial
+  private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /** The attribute name. */
-  private String name;
+  private final String name;
 
   /** The attribute friendly name. */
-  private String friendlyName;
+  private final String friendlyName;
 
   /**
    * The name format of this attribute. The default is {@code urn:oasis:names:tc:SAML:2.0:attrname-format:uri}
    * ({@link Attribute#URI_REFERENCE}).
    */
-  private String nameFormat = Attribute.URI_REFERENCE;
+  private final String nameFormat;
 
   /**
    * Creates an attribute template with the given name and friendly name, the default name format
-   * {@code urn:oasis:names:tc:SAML:2.0:attrname-format:uri} ({@link Attribute#URI_REFERENCE}) and not multi-valued.
+   * {@code urn:oasis:names:tc:SAML:2.0:attrname-format:uri} ({@link Attribute#URI_REFERENCE}) and not multivalued.
    *
    * @param name the attribute name
    * @param friendlyName the attribute friendly name (optional)
@@ -102,7 +105,7 @@ public class AttributeTemplate implements Serializable {
    * @return a builder
    */
   public AttributeBuilder createBuilder() {
-    AttributeBuilder builder = new AttributeBuilder(this.name);
+    final AttributeBuilder builder = new AttributeBuilder(this.name);
     return builder.friendlyName(this.friendlyName).nameFormat(this.nameFormat);
   }
 

--- a/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeUtils.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/attribute/AttributeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.attribute;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.schema.XSBoolean;
@@ -30,6 +24,12 @@ import org.opensaml.core.xml.schema.XSInteger;
 import org.opensaml.core.xml.schema.XSString;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.saml2.core.Attribute;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Helper methods for accessing attribute values. See also {@link AttributeBuilder}.
@@ -131,7 +131,7 @@ public class AttributeUtils {
     if (type.isInstance(obj)) {
       return Stream.of(type.cast(obj));
     }
-    else if (XSAny.class.isInstance(obj)) {
+    else if (obj instanceof XSAny) {
       if (type.isAssignableFrom(XSString.class)) {
         final XSString newObject = (XSString) XMLObjectSupport.buildXMLObject(XSString.TYPE_NAME);
         newObject.setValue(((XSAny) obj).getTextContent());
@@ -176,7 +176,7 @@ public class AttributeUtils {
             return Stream.of(type.cast(newObject));
           }
         }
-        catch (final Exception e) {
+        catch (final Exception ignored) {
         }
       }
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/attribute/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/attribute/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Package containing interfaces and classes handling SAML v2 Attributes.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AbstractAuthnRequestBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AbstractAuthnRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.core.Scoping;
 import org.opensaml.saml.saml2.core.Subject;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
 
 /**
@@ -148,7 +147,7 @@ public abstract class AbstractAuthnRequestBuilder<BUILDER extends AbstractSAMLOb
           ? XMLObjectSupport.cloneXMLObject(subject)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();
@@ -167,7 +166,7 @@ public abstract class AbstractAuthnRequestBuilder<BUILDER extends AbstractSAMLOb
           ? XMLObjectSupport.cloneXMLObject(nameIDPolicy)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();
@@ -185,7 +184,7 @@ public abstract class AbstractAuthnRequestBuilder<BUILDER extends AbstractSAMLOb
           ? XMLObjectSupport.cloneXMLObject(conditions)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();
@@ -204,7 +203,7 @@ public abstract class AbstractAuthnRequestBuilder<BUILDER extends AbstractSAMLOb
           ? XMLObjectSupport.cloneXMLObject(requestedAuthnContext)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();
@@ -222,7 +221,7 @@ public abstract class AbstractAuthnRequestBuilder<BUILDER extends AbstractSAMLOb
           ? XMLObjectSupport.cloneXMLObject(scoping)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AbstractRequestBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AbstractRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.core.build;
 
-import java.time.Instant;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
@@ -25,16 +23,16 @@ import org.opensaml.saml.saml2.core.Extensions;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
+
+import java.time.Instant;
 
 /**
  * Abstract builder class for building request messages.
  *
- * @author Martin Lindström (martin@idsec.se)
- *
  * @param <T> the type of request message
  * @param <BUILDER> the builder type
+ * @author Martin Lindström (martin@idsec.se)
  */
 public abstract class AbstractRequestBuilder<T extends RequestAbstractType, BUILDER extends AbstractSAMLObjectBuilder<T>>
     extends AbstractSAMLObjectBuilder<T> {
@@ -149,7 +147,7 @@ public abstract class AbstractRequestBuilder<T extends RequestAbstractType, BUIL
           ? XMLObjectSupport.cloneXMLObject(issuer)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this.getThis();

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AuthnRequestBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/AuthnRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/ExtensionsBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/ExtensionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ExtensionsBuilder extends AbstractSAMLObjectBuilder<Extensions> {
           this.object().getUnknownXMLObjects().add(XMLObjectSupport.cloneXMLObject(obj));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -96,7 +96,7 @@ public class ExtensionsBuilder extends AbstractSAMLObjectBuilder<Extensions> {
     try {
       this.object().getUnknownXMLObjects().add(XMLObjectSupport.cloneXMLObject(extension));
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this;

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/NameIDPolicyBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/NameIDPolicyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/RequestedAuthnContextBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/RequestedAuthnContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/ScopingBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/ScopingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.core.build;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
@@ -26,9 +23,11 @@ import org.opensaml.saml.saml2.core.IDPEntry;
 import org.opensaml.saml.saml2.core.IDPList;
 import org.opensaml.saml.saml2.core.RequesterID;
 import org.opensaml.saml.saml2.core.Scoping;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
 import se.swedenconnect.opensaml.common.builder.SAMLObjectBuilderRuntimeException;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Builder class for {@code Scoping} elements.
@@ -83,7 +82,7 @@ public class ScopingBuilder extends AbstractSAMLObjectBuilder<Scoping> {
               idpList.getIDPEntrys().add(XMLObjectSupport.cloneXMLObject(e));
             }
           }
-          catch (MarshallingException | UnmarshallingException e1) {
+          catch (final MarshallingException | UnmarshallingException e1) {
             throw new SAMLObjectBuilderRuntimeException(e1);
           }
         }
@@ -113,7 +112,7 @@ public class ScopingBuilder extends AbstractSAMLObjectBuilder<Scoping> {
    * @return an IDPEntry element
    */
   public static IDPEntry idpEntry(final String providerID, final String name, final String loc) {
-    IDPEntry entry = (IDPEntry) XMLObjectSupport.buildXMLObject(IDPEntry.DEFAULT_ELEMENT_NAME);
+    final IDPEntry entry = (IDPEntry) XMLObjectSupport.buildXMLObject(IDPEntry.DEFAULT_ELEMENT_NAME);
     entry.setProviderID(providerID);
     entry.setName(name);
     entry.setLoc(loc);

--- a/src/main/java/se/swedenconnect/opensaml/saml2/core/build/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/core/build/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Builder classes for core SAML classes.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/AbstractMetadataContainer.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/AbstractMetadataContainer.java
@@ -15,12 +15,8 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata;
 
-import java.security.InvalidAlgorithmParameterException;
-import java.security.SecureRandom;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
-
+import net.shibboleth.shared.security.RandomIdentifierParameterSpec;
+import net.shibboleth.shared.security.impl.RandomIdentifierGenerationStrategy;
 import org.apache.commons.codec.binary.Hex;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
@@ -35,17 +31,19 @@ import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-
-import net.shibboleth.shared.security.RandomIdentifierParameterSpec;
-import net.shibboleth.shared.security.impl.RandomIdentifierGenerationStrategy;
 import se.swedenconnect.opensaml.xmlsec.signature.support.SAMLObjectSigner;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Abstract base class for the {@link MetadataContainer} interface.
  *
- * @author Martin Lindström (martin@idsec.se)
- *
  * @param <T> the contained type
+ * @author Martin Lindström (martin@idsec.se)
  */
 public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & SignableSAMLObject & CacheableSAMLObject>
     implements MetadataContainer<T> {
@@ -89,8 +87,8 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
    * Constructor assigning the encapsulated descriptor element.
    *
    * @param descriptor the descriptor object
-   * @param signatureCredentials the signature credentials for signing the descriptor. May be null, but then no signing
-   *          will be possible
+   * @param signatureCredentials the signature credentials for signing the descriptor. May be null, but then no
+   *     signing will be possible
    */
   public AbstractMetadataContainer(final T descriptor, final X509Credential signatureCredentials) {
     this.descriptor = descriptor;
@@ -165,8 +163,8 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
     }
 
     SAMLObjectSigner.sign(this.descriptor, this.signatureCredentials,
-        Optional.ofNullable(this.signingConfiguration).orElseGet(() ->
-          SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration()));
+        Optional.ofNullable(this.signingConfiguration).orElseGet(
+            SecurityConfigurationSupport::getGlobalSignatureSigningConfiguration));
 
     log.debug("Descriptor '{}' successfully signed.", this.getLogString(this.descriptor));
 
@@ -204,7 +202,8 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
   }
 
   /**
-   * Assigns the factor (between 0 and 1) that is used to compute whether it is time to update the contained descriptor.
+   * Assigns the factor (between 0 and 1) that is used to compute whether it is time to update the contained
+   * descriptor.
    * <p>
    * The default value is {@link #DEFAULT_UPDATE_FACTOR}.
    * </p>

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntitiesDescriptorContainer.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntitiesDescriptorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntityDescriptorContainer.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntityDescriptorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntityDescriptorUtils.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/EntityDescriptorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata;
 
-import java.io.ByteArrayInputStream;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.xml.namespace.QName;
-
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.ext.saml2alg.DigestMethod;
@@ -40,9 +28,19 @@ import org.opensaml.security.credential.UsageType;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Credential;
 import org.opensaml.xmlsec.signature.X509Data;
-
 import se.swedenconnect.opensaml.saml2.attribute.AttributeConstants;
 import se.swedenconnect.opensaml.saml2.attribute.AttributeUtils;
+
+import javax.xml.namespace.QName;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utility methods for accessing metadata elements.
@@ -52,13 +50,13 @@ import se.swedenconnect.opensaml.saml2.attribute.AttributeUtils;
 public class EntityDescriptorUtils {
 
   /** Factory for creating certificates. */
-  private static CertificateFactory certFactory = null;
+  private static final CertificateFactory certFactory;
 
   static {
     try {
       certFactory = CertificateFactory.getInstance("X.509");
     }
-    catch (CertificateException e) {
+    catch (final CertificateException e) {
       throw new SecurityException(e);
     }
   }
@@ -145,7 +143,7 @@ public class EntityDescriptorUtils {
       final UsageType usageType) {
     final List<X509Credential> creds = new ArrayList<>();
     for (final KeyDescriptor kd : descriptor.getKeyDescriptors()) {
-      if (usageType.equals(kd.getUse()) || kd.getUse() == null || UsageType.UNSPECIFIED.equals(kd.getUse())) {
+      if (usageType == kd.getUse() || kd.getUse() == null || UsageType.UNSPECIFIED == kd.getUse()) {
         if (kd.getKeyInfo() == null) {
           continue;
         }
@@ -155,7 +153,7 @@ public class EntityDescriptorUtils {
               creds.add(new BasicX509Credential((X509Certificate) certFactory.generateCertificate(
                   new ByteArrayInputStream(Base64.getDecoder().decode(cert.getValue())))));
             }
-            catch (Exception e) {
+            catch (final Exception ignored) {
             }
           }
         }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/HolderOfKeyMetadataSupport.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/HolderOfKeyMetadataSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/MetadataContainer.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/MetadataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata;
 
-import java.time.Duration;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.saml.common.SignableSAMLObject;
@@ -25,13 +23,14 @@ import org.opensaml.saml.saml2.common.TimeBoundSAMLObject;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.w3c.dom.Element;
 
+import java.time.Duration;
+
 /**
  * An interface that encapsulates an {@code EntityDescriptor} or {@code EntitiesDescriptor} in a container and defines
  * useful method - mainly for publishing the metadata for an entity or a federation.
  *
- * @author Martin Lindström (martin@idsec.se)
- *
  * @param <T> the contained type
+ * @author Martin Lindström (martin@idsec.se)
  */
 public interface MetadataContainer<T extends TimeBoundSAMLObject & SignableSAMLObject & CacheableSAMLObject> {
 
@@ -56,7 +55,7 @@ public interface MetadataContainer<T extends TimeBoundSAMLObject & SignableSAMLO
    * and validity. The method will also take into account the update interval configured for this instance of the
    * container.
    *
-   * @param signatureRequired should be set if signatures are required for a entry to be regarded valid
+   * @param signatureRequired should be set if signatures are required for an entry to be regarded valid
    * @return if the encapsulated descriptor needs to be updated true is returned, otherwise false
    */
   boolean updateRequired(final boolean signatureRequired);

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/PeerMetadataResolver.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/PeerMetadataResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AbstractSSODescriptorBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AbstractSSODescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.build;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
@@ -27,8 +24,10 @@ import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.opensaml.saml.saml2.metadata.NameIDFormat;
 import org.opensaml.saml.saml2.metadata.SSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Abstract base class for building a {@link SSODescriptor}.
@@ -79,7 +78,7 @@ public abstract class AbstractSSODescriptorBuilder<T extends SSODescriptor, B ex
           this.object().getKeyDescriptors().add(XMLObjectSupport.cloneXMLObject(kd));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -168,7 +167,7 @@ public abstract class AbstractSSODescriptorBuilder<T extends SSODescriptor, B ex
           this.object().getSingleLogoutServices().add(XMLObjectSupport.cloneXMLObject(slo));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AssertionConsumerServiceBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AssertionConsumerServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package se.swedenconnect.opensaml.saml2.metadata.build;
 
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
 import se.swedenconnect.opensaml.saml2.metadata.HolderOfKeyMetadataSupport;
 

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AttributeConsumingServiceBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/AttributeConsumingServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.build;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
@@ -25,9 +22,11 @@ import org.opensaml.saml.saml2.metadata.AttributeConsumingService;
 import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 import org.opensaml.saml.saml2.metadata.ServiceDescription;
 import org.opensaml.saml.saml2.metadata.ServiceName;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
 import se.swedenconnect.opensaml.common.utils.LocalizedString;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Builder for {@code md:AttributeConsumingService} elements.
@@ -88,10 +87,9 @@ public class AttributeConsumingServiceBuilder extends AbstractSAMLObjectBuilder<
   }
 
   /**
-   * @see #serviceNames(List)
-   *
    * @param names the service names
    * @return the builder.
+   * @see #serviceNames(List)
    */
   public AttributeConsumingServiceBuilder serviceNames(final LocalizedString... names) {
     return this.serviceNames(names != null ? Arrays.asList(names) : null);
@@ -119,10 +117,9 @@ public class AttributeConsumingServiceBuilder extends AbstractSAMLObjectBuilder<
   }
 
   /**
-   * @see #descriptions(List)
-   *
    * @param descriptions the descriptions
    * @return the builder
+   * @see #descriptions(List)
    */
   public AttributeConsumingServiceBuilder descriptions(final LocalizedString... descriptions) {
     return this.descriptions(descriptions != null ? Arrays.asList(descriptions) : null);
@@ -145,7 +142,7 @@ public class AttributeConsumingServiceBuilder extends AbstractSAMLObjectBuilder<
           this.object().getRequestedAttributes().add(XMLObjectSupport.cloneXMLObject(attribute));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -153,10 +150,9 @@ public class AttributeConsumingServiceBuilder extends AbstractSAMLObjectBuilder<
   }
 
   /**
-   * @see #requestedAttributes(List)
-   *
    * @param attributes the requested attributes
    * @return the builder
+   * @see #requestedAttributes(List)
    */
   public AttributeConsumingServiceBuilder requestedAttributes(final RequestedAttribute... attributes) {
     return this.requestedAttributes(attributes != null ? Arrays.asList(attributes) : null);

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ContactPersonBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ContactPersonBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/DigestMethodBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/DigestMethodBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/DiscoveryResponseBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/DiscoveryResponseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EncryptionMethodBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EncryptionMethodBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class EncryptionMethodBuilder extends AbstractSAMLObjectBuilder<Encryptio
    * @return the builder
    */
   public EncryptionMethodBuilder keySize(final Integer keySize) {
-    KeySize size = (KeySize) XMLObjectSupport.buildXMLObject(KeySize.DEFAULT_ELEMENT_NAME);
+    final KeySize size = (KeySize) XMLObjectSupport.buildXMLObject(KeySize.DEFAULT_ELEMENT_NAME);
     this.object().setKeySize(size);
     return this;
   }
@@ -99,7 +99,7 @@ public class EncryptionMethodBuilder extends AbstractSAMLObjectBuilder<Encryptio
    * @return the builder
    */
   public EncryptionMethodBuilder oAEPparams(final String base64Encoding) {
-    OAEPparams p = (OAEPparams) XMLObjectSupport.buildXMLObject(OAEPparams.DEFAULT_ELEMENT_NAME);
+    final OAEPparams p = (OAEPparams) XMLObjectSupport.buildXMLObject(OAEPparams.DEFAULT_ELEMENT_NAME);
     this.object().setOAEPparams(p);
     return this;
   }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityAttributesBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityAttributesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class EntityAttributesBuilder extends AbstractSAMLObjectBuilder<EntityAtt
       try {
         this.object().getAttributes().add(XMLObjectSupport.cloneXMLObject(attribute));
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -120,9 +120,9 @@ public class EntityAttributesBuilder extends AbstractSAMLObjectBuilder<EntityAtt
       if (uris != null && !uris.isEmpty()) {
         assuranceCertification.getAttributeValues().clear();
         for (final String u : uris) {
-          final XSString sv = XSString.class.cast(
-              XMLObjectSupport.getBuilder(XSString.TYPE_NAME).buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,
-                  XSString.TYPE_NAME));
+          final XSString sv = (XSString) XMLObjectSupport.getBuilder(XSString.TYPE_NAME)
+              .buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,
+                  XSString.TYPE_NAME);
           sv.setValue(u);
           assuranceCertification.getAttributeValues().add(sv);
         }
@@ -174,9 +174,9 @@ public class EntityAttributesBuilder extends AbstractSAMLObjectBuilder<EntityAtt
       if (uris != null && !uris.isEmpty()) {
         entityCategories.getAttributeValues().clear();
         for (final String u : uris) {
-          final XSString sv = XSString.class.cast(
-              XMLObjectSupport.getBuilder(XSString.TYPE_NAME).buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,
-                  XSString.TYPE_NAME));
+          final XSString sv = (XSString) XMLObjectSupport.getBuilder(XSString.TYPE_NAME)
+              .buildObject(AttributeValue.DEFAULT_ELEMENT_NAME,
+                  XSString.TYPE_NAME);
           sv.setValue(u);
           entityCategories.getAttributeValues().add(sv);
         }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityDescriptorBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityDescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ public class EntityDescriptorBuilder extends AbstractSAMLObjectBuilder<EntityDes
           this.object().getRoleDescriptors().add(XMLObjectSupport.cloneXMLObject(rd));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -275,7 +275,7 @@ public class EntityDescriptorBuilder extends AbstractSAMLObjectBuilder<EntityDes
           ? XMLObjectSupport.cloneXMLObject(organization)
           : null);
     }
-    catch (MarshallingException | UnmarshallingException e) {
+    catch (final MarshallingException | UnmarshallingException e) {
       throw new RuntimeException(e);
     }
     return this;
@@ -290,13 +290,13 @@ public class EntityDescriptorBuilder extends AbstractSAMLObjectBuilder<EntityDes
   public EntityDescriptorBuilder contactPersons(final List<ContactPerson> contactPersons) {
     this.object().getContactPersons().clear();
     if (contactPersons != null) {
-      for (ContactPerson cp : contactPersons) {
+      for (final ContactPerson cp : contactPersons) {
         try {
           if (cp != null) {
             this.object().getContactPersons().add(XMLObjectSupport.cloneXMLObject(cp));
           }
         }
-        catch (MarshallingException | UnmarshallingException e) {
+        catch (final MarshallingException | UnmarshallingException e) {
           throw new RuntimeException(e);
         }
       }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ExtensionsBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ExtensionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class ExtensionsBuilder extends AbstractSAMLObjectBuilder<Extensions> {
           this.object().getUnknownXMLObjects().add(XMLObjectSupport.cloneXMLObject(obj));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -114,7 +114,7 @@ public class ExtensionsBuilder extends AbstractSAMLObjectBuilder<Extensions> {
           this.object().getUnknownXMLObjects().add(XMLObjectSupport.cloneXMLObject(obj));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/IDPSSODescriptorBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/IDPSSODescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.build;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Builder for {@link IDPSSODescriptor} objects.
@@ -91,7 +91,7 @@ public class IDPSSODescriptorBuilder extends AbstractSSODescriptorBuilder<IDPSSO
           this.object().getSingleSignOnServices().add(XMLObjectSupport.cloneXMLObject(sso));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -125,7 +125,7 @@ public class IDPSSODescriptorBuilder extends AbstractSSODescriptorBuilder<IDPSSO
           this.object().getAttributes().add(XMLObjectSupport.cloneXMLObject(a));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/KeyDescriptorBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/KeyDescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.build;
 
-import java.io.InputStream;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
-
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
@@ -34,8 +25,16 @@ import org.opensaml.security.x509.X509Credential;
 import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.KeyName;
 import org.opensaml.xmlsec.signature.X509Data;
-
 import se.swedenconnect.opensaml.common.builder.AbstractSAMLObjectBuilder;
+
+import java.io.InputStream;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
 
 /**
  * A builder for {@code KeyDescriptor} elements.
@@ -70,7 +69,7 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
    * @return the builder
    */
   public KeyDescriptorBuilder use(final UsageType usageType) {
-    if (UsageType.UNSPECIFIED.equals(usageType)) {
+    if (UsageType.UNSPECIFIED == usageType) {
       this.object().setUse(null);
     }
     else {
@@ -102,7 +101,8 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
   }
 
   /**
-   * Assigns a certificate to be used as a X.509 data element of the {@code KeyInfo} element within the key descriptor.
+   * Assigns a certificate to be used as an X.509 data element of the {@code KeyInfo} element within the key
+   * descriptor.
    *
    * @param certificate the certificate
    * @return the builder
@@ -112,14 +112,14 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
       return this.certificate(
           certificate != null ? Base64.getEncoder().encodeToString(certificate.getEncoded()) : null);
     }
-    catch (CertificateEncodingException e) {
+    catch (final CertificateEncodingException e) {
       throw new SecurityException(e);
     }
   }
 
   /**
-   * Assigns an input stream to a certificate resource that is to be used as a X.509 data element of the {@code KeyInfo}
-   * element within the key descriptor.
+   * Assigns an input stream to a certificate resource that is to be used as an X.509 data element of the
+   * {@code KeyInfo} element within the key descriptor.
    *
    * @param certificate the certificate resource
    * @return the builder
@@ -130,13 +130,13 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
           certificate != null ? Base64.getEncoder().encodeToString(
               CertificateFactory.getInstance("X.509").generateCertificate(certificate).getEncoded()) : null);
     }
-    catch (CertificateException e) {
+    catch (final CertificateException e) {
       throw new SecurityException(e);
     }
   }
 
   /**
-   * Assigns a certificate (in Base64-encoded format) to be used as a X.509 data element of the {@code KeyInfo} element
+   * Assigns a certificate (in Base64-encoded format) to be used as an X.509 data element of the {@code KeyInfo} element
    * within the key descriptor.
    *
    * @param base64Encoding the base64 encoding (note: not PEM-format)
@@ -153,7 +153,7 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
     }
     this.object().getKeyInfo().getX509Datas().clear();
     final X509Data x509Data = (X509Data) XMLObjectSupport.buildXMLObject(X509Data.DEFAULT_ELEMENT_NAME);
-    org.opensaml.xmlsec.signature.X509Certificate cert =
+    final org.opensaml.xmlsec.signature.X509Certificate cert =
         (org.opensaml.xmlsec.signature.X509Certificate) XMLObjectSupport
             .buildXMLObject(org.opensaml.xmlsec.signature.X509Certificate.DEFAULT_ELEMENT_NAME);
     cert.setValue(base64Encoding);
@@ -163,7 +163,7 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
   }
 
   /**
-   * Assigns a certificate in OpenSAML credential format to be used as a X.509 data element of the {@code KeyInfo}
+   * Assigns a certificate in OpenSAML credential format to be used as an X.509 data element of the {@code KeyInfo}
    * element within the key descriptor.
    *
    * @param credential the credential
@@ -222,7 +222,7 @@ public class KeyDescriptorBuilder extends AbstractSAMLObjectBuilder<KeyDescripto
             this.object().getEncryptionMethods().add(XMLObjectSupport.cloneXMLObject(em));
           }
         }
-        catch (MarshallingException | UnmarshallingException e) {
+        catch (final MarshallingException | UnmarshallingException e) {
           throw new RuntimeException(e);
         }
       }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/LogoBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/LogoBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/OrganizationBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/OrganizationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/RequestedAttributeBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/RequestedAttributeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SPSSODescriptorBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SPSSODescriptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class SPSSODescriptorBuilder extends AbstractSSODescriptorBuilder<SPSSODe
           this.object().getAssertionConsumerServices().add(XMLObjectSupport.cloneXMLObject(a));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }
@@ -139,7 +139,7 @@ public class SPSSODescriptorBuilder extends AbstractSSODescriptorBuilder<SPSSODe
           this.object().getAttributeConsumingServices().add(XMLObjectSupport.cloneXMLObject(a));
         }
       }
-      catch (MarshallingException | UnmarshallingException e) {
+      catch (final MarshallingException | UnmarshallingException e) {
         throw new RuntimeException(e);
       }
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ScopeBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/ScopeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SigningMethodBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SigningMethodBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SingleLogoutServiceBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SingleLogoutServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SingleSignOnServiceBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/SingleSignOnServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/UIInfoBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/UIInfoBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ public class UIInfoBuilder extends AbstractSAMLObjectBuilder<UIInfo> {
       }
       return this;
     }
-    catch (UnmarshallingException | MarshallingException e) {
+    catch (final UnmarshallingException | MarshallingException e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/build/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Classes for creating metadata elements using the builder pattern.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Extended SAML metadata support.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/AbstractMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/AbstractMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,10 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.xml.namespace.QName;
-
+import net.shibboleth.shared.component.AbstractInitializableComponent;
+import net.shibboleth.shared.component.ComponentInitializationException;
+import net.shibboleth.shared.resolver.CriteriaSet;
+import net.shibboleth.shared.resolver.ResolverException;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.MarshallingException;
@@ -35,7 +26,6 @@ import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.common.xml.SAMLSchemaBuilder;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.RefreshableMetadataResolver;
-import org.opensaml.saml.metadata.resolver.filter.FilterException;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilter;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilterChain;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilterContext;
@@ -57,10 +47,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
-import net.shibboleth.shared.component.AbstractInitializableComponent;
-import net.shibboleth.shared.component.ComponentInitializationException;
-import net.shibboleth.shared.resolver.CriteriaSet;
-import net.shibboleth.shared.resolver.ResolverException;
+import javax.annotation.Nonnull;
+import javax.xml.namespace.QName;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base class for the {@link MetadataProvider} interface.
@@ -70,7 +67,7 @@ import net.shibboleth.shared.resolver.ResolverException;
 public abstract class AbstractMetadataProvider extends AbstractInitializableComponent implements MetadataProvider {
 
   /** Logging instance. */
-  private final Logger log = LoggerFactory.getLogger(AbstractMetadataProvider.class);
+  private static final Logger log = LoggerFactory.getLogger(AbstractMetadataProvider.class);
 
   /** Whether the metadata returned by queries must be valid. Default: true. */
   private boolean requireValidMetadata = true;
@@ -124,7 +121,7 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
   /** {@inheritDoc} */
   @Override
   public Instant getLastUpdate() {
-    if (RefreshableMetadataResolver.class.isInstance(this.getMetadataResolver())) {
+    if (this.getMetadataResolver() instanceof RefreshableMetadataResolver) {
       return ((RefreshableMetadataResolver) this.getMetadataResolver()).getLastUpdate();
     }
     return this.downloadTime;
@@ -133,11 +130,11 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
   /** {@inheritDoc} */
   @Override
   public void refresh() throws ResolverException {
-    if (RefreshableMetadataResolver.class.isInstance(this.getMetadataResolver())) {
+    if (this.getMetadataResolver() instanceof RefreshableMetadataResolver) {
       ((RefreshableMetadataResolver) this.getMetadataResolver()).refresh();
     }
     else {
-      this.log.debug("Refresh of metadata is not supported by {}", this.getClass().getName());
+      log.debug("Refresh of metadata is not supported by {}", this.getClass().getName());
     }
   }
 
@@ -228,7 +225,7 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
     // Verify signature?
     if (this.signatureVerificationCertificates != null && !this.signatureVerificationCertificates.isEmpty()) {
       final CredentialResolver credentialResolver = new StaticCredentialResolver(
-          this.signatureVerificationCertificates.stream().map(c -> new BasicX509Credential(c))
+          this.signatureVerificationCertificates.stream().map(BasicX509Credential::new)
               .collect(Collectors.toList()));
       final ExplicitKeySignatureTrustEngine trustEngine = new ExplicitKeySignatureTrustEngine(credentialResolver,
           DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
@@ -272,7 +269,7 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
       }
 
       @Override
-      public XMLObject filter(final XMLObject metadata, final MetadataFilterContext context) throws FilterException {
+      public XMLObject filter(final XMLObject metadata, @Nonnull final MetadataFilterContext context) {
         AbstractMetadataProvider.this.setMetadata(metadata);
         return metadata;
       }
@@ -305,7 +302,7 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
    *
    * @param requireValidMetadata should be passed into {@link MetadataResolver#setRequireValidMetadata(boolean)}
    * @param failFastInitialization should be passed into
-   *          {@link AbstractMetadataResolver#setFailFastInitialization(boolean)} (if applicable)
+   *     {@link AbstractMetadataResolver#setFailFastInitialization(boolean)} (if applicable)
    * @param filter filter that must be installed for the resolver
    * @throws ResolverException for errors creating the resolver
    */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/AbstractMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/AbstractMetadataProvider.java
@@ -29,6 +29,7 @@ import org.opensaml.saml.metadata.resolver.RefreshableMetadataResolver;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilter;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilterChain;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilterContext;
+import org.opensaml.saml.metadata.resolver.filter.impl.EntityRoleFilter;
 import org.opensaml.saml.metadata.resolver.filter.impl.PredicateFilter;
 import org.opensaml.saml.metadata.resolver.filter.impl.PredicateFilter.Direction;
 import org.opensaml.saml.metadata.resolver.filter.impl.SchemaValidationFilter;
@@ -86,6 +87,9 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
 
   /** Tells whether XML schema validation should be performed on downloaded metadata. Default: false. */
   private boolean performSchemaValidation = false;
+
+  /** Tells whether we should keep only SP and IdP role descriptors. The default is true. */
+  private boolean keepOnlySpAndIdps = true;
 
   /** A list of inclusion predicates that will be applied to downloaded metadata. */
   private List<Predicate<EntityDescriptor>> inclusionPredicates = null;
@@ -242,6 +246,14 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
       filters.add(schemaValidationFilter);
     }
 
+    // Keep only SP:s and IdP:s?
+    if (this.keepOnlySpAndIdps) {
+      final EntityRoleFilter entityRoleFilter = new EntityRoleFilter(
+          List.of(SPSSODescriptor.DEFAULT_ELEMENT_NAME, IDPSSODescriptor.DEFAULT_ELEMENT_NAME));
+      entityRoleFilter.initialize();
+      filters.add(entityRoleFilter);
+    }
+
     // Inclusion predicates?
     if (this.inclusionPredicates != null) {
       for (final Predicate<EntityDescriptor> p : this.inclusionPredicates) {
@@ -386,6 +398,16 @@ public abstract class AbstractMetadataProvider extends AbstractInitializableComp
   public void setPerformSchemaValidation(final boolean performSchemaValidation) {
     this.checkSetterPreconditions();
     this.performSchemaValidation = performSchemaValidation;
+  }
+
+  /**
+   * Tells whether we should keep only SP and IdP role descriptors. The default is true.
+   *
+   * @param keepOnlySpAndIdps whether to keep only SPs and IdPs.
+   */
+  public void setKeepOnlySpAndIdps(final boolean keepOnlySpAndIdps) {
+    this.checkSetterPreconditions();
+    this.keepOnlySpAndIdps = keepOnlySpAndIdps;
   }
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/CompositeMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/CompositeMetadataProvider.java
@@ -154,6 +154,7 @@ public class CompositeMetadataProvider extends AbstractMetadataProvider {
     // Time to collect new metadata from the providers?
     //
     if (this.compositeMetadata == null || this.compositeMetadataCreationTime.isBefore(lastUpdate)) {
+
       this.collectMetadata();
     }
     return this.compositeMetadata;
@@ -202,8 +203,7 @@ public class CompositeMetadataProvider extends AbstractMetadataProvider {
         if (entityIds.contains(ed.getEntityID())) {
           log.warn(
               "EntityDescriptor for '{}' already exists in metadata. Entry read from provider '{}' will be ignored.",
-              ed.getEntityID(),
-              provider.getID());
+              ed.getEntityID(), provider.getID());
           continue;
         }
         try {

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/FilesystemMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/FilesystemMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class FilesystemMetadataProvider extends AbstractMetadataProvider {
   private FilesystemMetadataResolver metadataResolver;
 
   /** The metadata source. */
-  private File metadataSource;
+  private final File metadataSource;
 
   /**
    * Constructor assigning the file holding the metadata.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.io.IOException;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import net.shibboleth.shared.collection.Pair;
+import net.shibboleth.shared.component.ComponentInitializationException;
+import net.shibboleth.shared.resolver.ResolverException;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
@@ -32,9 +30,9 @@ import org.opensaml.saml.metadata.resolver.impl.FunctionDrivenDynamicHTTPMetadat
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
-import net.shibboleth.shared.collection.Pair;
-import net.shibboleth.shared.component.ComponentInitializationException;
-import net.shibboleth.shared.resolver.ResolverException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
 
 /**
  * A {@link MetadataProvider} that supports the <a href="https://www.ietf.org/id/draft-young-md-query-17.html">MDQ
@@ -60,8 +58,8 @@ public class MDQMetadataProvider extends AbstractMetadataProvider {
    * entities.
    *
    * @param metadataBaseUrl the base metadata URL (must not end with a /)
-   * @param httpClient the HTTP client instance to use, if null, {@link HTTPMetadataProvider#createDefaultHttpClient()}
-   *          is used to create a default client
+   * @param httpClient the HTTP client instance to use, if null,
+   *     {@link HTTPMetadataProvider#createDefaultHttpClient()} is used to create a default client
    * @param cacheBaseDir the base directory where caches will be stored, if null, the caches are kept in memory
    * @throws ResolverException for failures setting up the underlying {@link MetadataResolver}
    */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQRequestURLBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQRequestURLBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import java.util.function.Function;
-
-import javax.annotation.Nullable;
-
+import net.shibboleth.shared.logic.Constraint;
+import net.shibboleth.shared.resolver.CriteriaSet;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.shibboleth.shared.logic.Constraint;
-import net.shibboleth.shared.resolver.CriteriaSet;
+import javax.annotation.Nullable;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * Function which examines an entity ID from supplied criteria and returns a metadata request URL for MDQ.
@@ -37,7 +35,7 @@ import net.shibboleth.shared.resolver.CriteriaSet;
 public class MDQRequestURLBuilder implements Function<CriteriaSet, String> {
 
   /** Logger. */
-  private final Logger log = LoggerFactory.getLogger(MDQRequestURLBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(MDQRequestURLBuilder.class);
 
   /** The metadata base URL. */
   private String baseUrl;
@@ -66,7 +64,8 @@ public class MDQRequestURLBuilder implements Function<CriteriaSet, String> {
     final String entityID = criteria.get(EntityIdCriterion.class).getEntityId();
     Constraint.isNotNull(entityID, "Entity ID was null");
 
-    final String url = String.format("%s/entities/%s", this.baseUrl, URLEncoder.encode(entityID, StandardCharsets.UTF_8));
+    final String url =
+        String.format("%s/entities/%s", this.baseUrl, URLEncoder.encode(entityID, StandardCharsets.UTF_8));
     log.debug("Returning request URL: {}", url);
     return url;
   }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MetadataProviderPredicates.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/MetadataProviderPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/ProxyMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/ProxyMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import net.shibboleth.shared.component.ComponentInitializationException;
 import org.apache.commons.lang3.Validate;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilter;
 import org.opensaml.saml.metadata.resolver.filter.MetadataFilterChain;
 import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 
-import net.shibboleth.shared.component.ComponentInitializationException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A metadata provider that is constructed by assigning an OpenSAML {@link MetadataResolver} instance.
@@ -34,7 +33,7 @@ import net.shibboleth.shared.component.ComponentInitializationException;
 public class ProxyMetadataProvider extends AbstractMetadataProvider {
 
   /** The metadata resolver that we wrap in this class. */
-  private AbstractMetadataResolver metadataResolver;
+  private final AbstractMetadataResolver metadataResolver;
 
   /**
    * Constructor assigning the OpenSAML metadata resolver that this instance should proxy.
@@ -46,7 +45,7 @@ public class ProxyMetadataProvider extends AbstractMetadataProvider {
    */
   public ProxyMetadataProvider(final MetadataResolver metadataResolver) {
     Validate.notNull(metadataResolver, "metadataResolver must not be null");
-    Validate.isTrue(AbstractMetadataResolver.class.isInstance(metadataResolver),
+    Validate.isTrue(metadataResolver instanceof AbstractMetadataResolver,
         "Supplied metadata resolver must extend AbstractMetadataResolver");
     this.metadataResolver = (AbstractMetadataResolver) metadataResolver;
   }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/StaticMetadataProvider.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/StaticMetadataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
+import net.shibboleth.shared.component.ComponentInitializationException;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -23,8 +24,6 @@ import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.w3c.dom.Element;
-
-import net.shibboleth.shared.component.ComponentInitializationException;
 
 /**
  * A {@code MetadataProvider} that is given an object representing SAML metadata (EntityDescriptor or
@@ -46,8 +45,7 @@ public class StaticMetadataProvider extends AbstractMetadataProvider {
   /**
    * Constructor that takes a DOM element representing the metadata.
    *
-   * @param element
-   *          DOM element
+   * @param element DOM element
    */
   public StaticMetadataProvider(final Element element) {
     this.element = element;
@@ -56,10 +54,8 @@ public class StaticMetadataProvider extends AbstractMetadataProvider {
   /**
    * Constructor that takes an {link EntityDescriptor} object.
    *
-   * @param entityDescriptor
-   *          the metadata EntityDescriptor
-   * @throws MarshallingException
-   *           if the supplied object cannot be marshalled
+   * @param entityDescriptor the metadata EntityDescriptor
+   * @throws MarshallingException if the supplied object cannot be marshalled
    */
   public StaticMetadataProvider(final EntityDescriptor entityDescriptor) throws MarshallingException {
     this.element = entityDescriptor.getDOM();
@@ -71,10 +67,8 @@ public class StaticMetadataProvider extends AbstractMetadataProvider {
   /**
    * Constructor that takes an {@link EntitiesDescriptor} object.
    *
-   * @param entitiesDescriptor
-   *          the metadata EntitiesDescriptor
-   * @throws MarshallingException
-   *           if the supplied object cannot be marshalled
+   * @param entitiesDescriptor the metadata EntitiesDescriptor
+   * @throws MarshallingException if the supplied object cannot be marshalled
    */
   public StaticMetadataProvider(final EntitiesDescriptor entitiesDescriptor) throws MarshallingException {
     this.element = entitiesDescriptor.getDOM();
@@ -88,7 +82,7 @@ public class StaticMetadataProvider extends AbstractMetadataProvider {
   public String getID() {
     if (this.id == null) {
       this.id = this.element.getAttribute("ID");
-      if (this.id == null || this.id.trim().length() == 0) {
+      if (this.id == null || this.id.trim().isEmpty()) {
         this.id = this.toString();
       }
     }
@@ -98,8 +92,7 @@ public class StaticMetadataProvider extends AbstractMetadataProvider {
   /**
    * Assigns the ID for the provider.
    *
-   * @param id
-   *          the ID
+   * @param id the ID
    */
   public void setID(final String id) {
     this.id = id;

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/provider/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * This library introduces the concept of a "metadata provider" which is a wrapper around a
  * {@link org.opensaml.saml.metadata.resolver.MetadataResolver} and allows for easier access

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/Scope.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,10 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.scope;
 
-import javax.xml.namespace.QName;
-
 import org.opensaml.core.xml.schema.XSBooleanValue;
 import org.opensaml.core.xml.schema.XSString;
 
-/**
- * XMLObject for the Shibboleth Scope metadata extension.
- * */
+import javax.xml.namespace.QName;
 
 /**
  * The Shibboleth Scope metadata extension.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/ScopeUtils.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/ScopeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,19 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.scope;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.PatternSyntaxException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.XMLRuntimeException;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-
 import se.swedenconnect.opensaml.saml2.attribute.AttributeUtils;
 import se.swedenconnect.opensaml.saml2.metadata.EntityDescriptorUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Utility methods for validating a scoped attribute against a {@code shibmd:Scope} element.
@@ -40,14 +39,13 @@ public class ScopeUtils {
   /**
    * Given an (IdP) {@link EntityDescriptor}, the method finds all {@code shibmd:Scope} elements.
    *
-   * @param entityDescriptor
-   *          the metadata object
+   * @param entityDescriptor the metadata object
    * @return a (possible empty) list of {@code shibmd:Scope} elements
    */
   public static List<XMLObject> getScopeExtensions(final EntityDescriptor entityDescriptor) {
     return Optional.ofNullable(entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS))
-      .map(d -> EntityDescriptorUtils.getMetadataExtensions(d.getExtensions(), Scope.DEFAULT_ELEMENT_NAME))
-      .orElse(Collections.emptyList());
+        .map(d -> EntityDescriptorUtils.getMetadataExtensions(d.getExtensions(), Scope.DEFAULT_ELEMENT_NAME))
+        .orElse(Collections.emptyList());
   }
 
   /**
@@ -57,17 +55,13 @@ public class ScopeUtils {
    * If an attribute that is not "scoped" (value@scope) the method returns {@code false}.
    * </p>
    *
-   * @param scopedAttribute
-   *          the attribute to test
-   * @param scopes
-   *          the shibmd:Scope elements
+   * @param scopedAttribute the attribute to test
+   * @param scopes the shibmd:Scope elements
    * @return true if the attribute scope is listed among the Scope extensions and false otherwise
    */
   public static boolean isAuthorized(final Attribute scopedAttribute, final List<XMLObject> scopes) {
     return scopes.stream()
-      .filter(s -> isMatch(s, scopedAttribute))
-      .findFirst()
-      .isPresent();
+        .anyMatch(s -> isMatch(s, scopedAttribute));
   }
 
   /**
@@ -77,17 +71,15 @@ public class ScopeUtils {
    * If the attribute contains multiple values, all must match the scope.
    * </p>
    *
-   * @param scope
-   *          the Scope element
-   * @param attribute
-   *          the attribute
+   * @param scope the Scope element
+   * @param attribute the attribute
    * @return true if there is a match and false otherwise
    */
   public static boolean isMatch(final XMLObject scope, final Attribute attribute) {
     if (attribute == null) {
       return false;
     }
-    List<String> attributeValues = AttributeUtils.getAttributeStringValues(attribute);
+    final List<String> attributeValues = AttributeUtils.getAttributeStringValues(attribute);
     for (final String a : attributeValues) {
       if (!isMatch(scope, a)) {
         return false;
@@ -100,10 +92,8 @@ public class ScopeUtils {
    * Given a {@code shibmd:Scope} element, the method tests whether the value of the (scoped) attribute matches the
    * scope.
    *
-   * @param scope
-   *          the Scope element
-   * @param attributeValue
-   *          the full attribute value
+   * @param scope the Scope element
+   * @param attributeValue the full attribute value
    * @return true if there is a match and false otherwise
    */
   public static boolean isMatch(final XMLObject scope, final String attributeValue) {
@@ -116,8 +106,8 @@ public class ScopeUtils {
       return false;
     }
 
-    boolean isRegexp = false;
-    String scopeValue = null;
+    final boolean isRegexp;
+    final String scopeValue;
 
     if (scope instanceof Scope) {
       isRegexp = ((Scope) scope).getRegexp();
@@ -149,8 +139,7 @@ public class ScopeUtils {
   /**
    * Gets the domain part (value@domain) from a scoped attribute value.
    *
-   * @param attributeValue
-   *          the attribute value
+   * @param attributeValue the attribute value
    * @return the domain part, or null
    */
   public static String getScopedDomain(final String attributeValue) {

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 package se.swedenconnect.opensaml.saml2.metadata.scope.impl;
 
 import org.opensaml.core.xml.AbstractXMLObjectBuilder;
-
 import se.swedenconnect.opensaml.saml2.metadata.scope.Scope;
+
+import javax.annotation.Nonnull;
 
 /**
  * Builder for {@link Scope} elements.
@@ -28,7 +29,8 @@ public class ScopeBuilder extends AbstractXMLObjectBuilder<Scope> {
 
   /** {@inheritDoc} */
   @Override
-  public Scope buildObject(final String namespaceURI, final String localName, final String namespacePrefix) {
+  @Nonnull
+  public Scope buildObject(final String namespaceURI, @Nonnull final String localName, final String namespacePrefix) {
     return new ScopeImpl(namespaceURI, localName, namespacePrefix);
   }
 
@@ -38,6 +40,6 @@ public class ScopeBuilder extends AbstractXMLObjectBuilder<Scope> {
    * @return a Scope object
    */
   public Scope buildObject() {
-    return buildObject("urn:mace:shibboleth:metadata:1.0", Scope.DEFAULT_ELEMENT_LOCAL_NAME, "shibmd");
+    return this.buildObject("urn:mace:shibboleth:metadata:1.0", Scope.DEFAULT_ELEMENT_LOCAL_NAME, "shibmd");
   }
 }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeImpl.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.scope.impl;
 
-/*
- * Licensed to the University Corporation for Advanced Internet Development,
- * Inc. (UCAID) under one or more contributor license agreements.  See the
- * NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The UCAID licenses this file to You under the Apache
- * License, Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import java.util.List;
 
 import org.opensaml.core.xml.AbstractXMLObject;

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeMarshaller.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.scope.impl;
 
+import jakarta.annotation.Nonnull;
+import net.shibboleth.shared.xml.ElementSupport;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.AbstractXMLObjectMarshaller;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.w3c.dom.Element;
-
-import net.shibboleth.shared.xml.ElementSupport;
 import se.swedenconnect.opensaml.saml2.metadata.scope.Scope;
 
 /**
@@ -32,7 +32,8 @@ public class ScopeMarshaller extends AbstractXMLObjectMarshaller {
 
   /** {@inheritDoc} */
   @Override
-  protected void marshallAttributes(final XMLObject xmlObject, final Element domElement) throws MarshallingException {
+  protected void marshallAttributes(@Nonnull final XMLObject xmlObject, @Nonnull final Element domElement)
+      throws MarshallingException {
     final Scope scope = (Scope) xmlObject;
     if (scope.getRegexpXSBoolean() != null) {
       domElement.setAttributeNS(null, Scope.REGEXP_ATTRIB_NAME, scope.getRegexpXSBoolean().toString());
@@ -41,7 +42,7 @@ public class ScopeMarshaller extends AbstractXMLObjectMarshaller {
 
   /** {@inheritDoc} */
   @Override
-  protected void marshallElementContent(final XMLObject xmlObject, final Element domElement)
+  protected void marshallElementContent(@Nonnull final XMLObject xmlObject, @Nonnull final Element domElement)
       throws MarshallingException {
     final Scope shibMDScope = (Scope) xmlObject;
     ElementSupport.appendTextContent(domElement, shibMDScope.getValue());

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeUnmarshaller.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/ScopeUnmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.scope.impl;
 
+import jakarta.annotation.Nonnull;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.AbstractXMLObjectUnmarshaller;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.w3c.dom.Attr;
-
 import se.swedenconnect.opensaml.saml2.metadata.scope.Scope;
 
 /**
@@ -31,7 +31,8 @@ public class ScopeUnmarshaller extends AbstractXMLObjectUnmarshaller {
 
   /** {@inheritDoc} */
   @Override
-  protected void processAttribute(final XMLObject xmlObject, final Attr attribute) throws UnmarshallingException {
+  protected void processAttribute(@Nonnull final XMLObject xmlObject, @Nonnull final Attr attribute)
+      throws UnmarshallingException {
     final Scope scope = (Scope) xmlObject;
     if (attribute.getLocalName().equals(Scope.REGEXP_ATTRIB_NAME)) {
       scope.setRegexp(Boolean.valueOf(attribute.getValue()));
@@ -40,7 +41,7 @@ public class ScopeUnmarshaller extends AbstractXMLObjectUnmarshaller {
 
   /** {@inheritDoc} */
   @Override
-  protected void processElementContent(final XMLObject xmlObject, final String elementContent) {
+  protected void processElementContent(@Nonnull final XMLObject xmlObject, @Nonnull final String elementContent) {
     final Scope scope = (Scope) xmlObject;
     scope.setValue(elementContent);
   }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/impl/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Implementation classes for the {@code Scope} element.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/metadata/scope/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Support for the Shibboleth <code>Scope</code> metadata element extension.
  * Note that this class is also defined in Shibboleth's idp-saml-api and idp-saml-impl libraries.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/AuthnRequestGenerator.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/AuthnRequestGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/AuthnRequestGeneratorContext.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/AuthnRequestGeneratorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.request;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -29,13 +23,19 @@ import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.AttributeConsumingService;
+import org.opensaml.saml.saml2.metadata.IndexedEndpoint;
 import org.opensaml.saml.saml2.metadata.NameIDFormat;
 import org.opensaml.security.x509.X509Credential;
 import org.opensaml.xmlsec.SecurityConfigurationSupport;
 import org.opensaml.xmlsec.SignatureSigningConfiguration;
-
 import se.swedenconnect.opensaml.saml2.core.build.NameIDPolicyBuilder;
 import se.swedenconnect.opensaml.saml2.core.build.RequestedAuthnContextBuilder;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Defines a context which can be used to control how
@@ -127,7 +127,7 @@ public interface AuthnRequestGeneratorContext {
    */
   default AssertionConsumerServiceResolver getAssertionConsumerServiceResolver() {
     return (list) -> list.stream()
-        .filter(a -> a.isDefault())
+        .filter(IndexedEndpoint::isDefault)
         .map(AssertionConsumerService::getLocation)
         .findFirst()
         .orElse(list.stream()
@@ -178,9 +178,9 @@ public interface AuthnRequestGeneratorContext {
   default RequestedAuthnContextBuilderFunction getRequestedAuthnContextBuilderFunction() {
     return (list, hok) -> !list.isEmpty()
         ? RequestedAuthnContextBuilder.builder()
-            .comparison(AuthnContextComparisonTypeEnumeration.EXACT)
-            .authnContextClassRefs(list)
-            .build()
+        .comparison(AuthnContextComparisonTypeEnumeration.EXACT)
+        .authnContextClassRefs(list)
+        .build()
         : null;
   }
 
@@ -199,8 +199,8 @@ public interface AuthnRequestGeneratorContext {
 
   /**
    * The {@link AuthnRequestGenerator} is normally configured with a signing credential
-   * (AuthnRequestGenerator#getSignCredential()}. This method exist so that we may override the default credential.
-   * Mainly for testing purposes.
+   * {@link AuthnRequestGenerator#getSignCredential()}. This method exist so that we may override the default
+   * credential. Mainly for testing purposes.
    * <p>
    * The default implementation returns {@code null}.
    * </p>
@@ -222,7 +222,7 @@ public interface AuthnRequestGeneratorContext {
    * cases it is up to the function to decide whether to return a {@code String} or an {@code Integer}.
    * </p>
    */
-  public interface AssertionConsumerServiceResolver extends Function<List<AssertionConsumerService>, Object> {
+  interface AssertionConsumerServiceResolver extends Function<List<AssertionConsumerService>, Object> {
   }
 
   /**
@@ -234,7 +234,7 @@ public interface AuthnRequestGeneratorContext {
    * If this function returns {@code null}, no {@code AttributeConsumingServiceIndex} attribute will be included.
    * </p>
    */
-  public interface AttributeConsumingServiceIndexResolver extends Function<List<AttributeConsumingService>, Integer> {
+  interface AttributeConsumingServiceIndexResolver extends Function<List<AttributeConsumingService>, Integer> {
   }
 
   /**
@@ -249,7 +249,7 @@ public interface AuthnRequestGeneratorContext {
    * If the resolver returns {@code null}, no {@code NameIDPolicy} will be included in the {@code AuthnRequest}.
    * </p>
    */
-  public interface NameIDPolicyBuilderFunction extends Function<List<NameIDFormat>, NameIDPolicy> {
+  interface NameIDPolicyBuilderFunction extends Function<List<NameIDFormat>, NameIDPolicy> {
   }
 
   /**
@@ -262,7 +262,7 @@ public interface AuthnRequestGeneratorContext {
    * If the function returns {@code null} no {@code RequestedAuthnContext} is added to the {@code AuthnRequest}.
    * </p>
    */
-  public interface RequestedAuthnContextBuilderFunction
+  interface RequestedAuthnContextBuilderFunction
       extends BiFunction<List<String>, Boolean, RequestedAuthnContext> {
   }
 
@@ -271,13 +271,13 @@ public interface AuthnRequestGeneratorContext {
    * {@link AuthnRequestGeneratorContext#getAuthnRequestCustomizer()} method for the customizer that may operate and add
    * customizations to the request object.
    */
-  public interface AuthnRequestCustomizer extends Consumer<AuthnRequest> {
+  interface AuthnRequestCustomizer extends Consumer<AuthnRequest> {
   }
 
   /**
    * Enumeration that tells whether the Holder-of-key WebSSO profile is required, optional or not active.
    */
-  public enum HokRequirement {
+  enum HokRequirement {
 
     /**
      * The SP will always use HoK - A call to
@@ -295,6 +295,6 @@ public interface AuthnRequestGeneratorContext {
      * The holder-of-key profile will never be used.
      */
     DONT_USE
-  };
+  }
 
 }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/DefaultAuthnRequestGenerator.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/DefaultAuthnRequestGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package se.swedenconnect.opensaml.saml2.request;
 
-import java.util.Optional;
-
+import net.shibboleth.shared.resolver.CriteriaSet;
+import net.shibboleth.shared.resolver.ResolverException;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
@@ -26,8 +26,7 @@ import org.opensaml.security.x509.X509Credential;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.shibboleth.shared.resolver.CriteriaSet;
-import net.shibboleth.shared.resolver.ResolverException;
+import java.util.Optional;
 
 /**
  * A default implementation of the {@link AuthnRequestGenerator} where a metadata resolver is used to locate metadata.
@@ -37,7 +36,7 @@ import net.shibboleth.shared.resolver.ResolverException;
 public class DefaultAuthnRequestGenerator extends AbstractAuthnRequestGenerator {
 
   /** Logging instance. */
-  private final Logger log = LoggerFactory.getLogger(DefaultAuthnRequestGenerator.class);
+  private static final Logger log = LoggerFactory.getLogger(DefaultAuthnRequestGenerator.class);
 
   /** The metadata resolver. */
   private final MetadataResolver metadataResolver;

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/RedirectRequestHttpObject.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/RedirectRequestHttpObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,10 @@
  */
 package se.swedenconnect.opensaml.saml2.request;
 
-import java.net.MalformedURLException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import net.shibboleth.shared.collection.Pair;
+import net.shibboleth.shared.net.URLBuilder;
+import net.shibboleth.shared.resolver.CriteriaSet;
+import net.shibboleth.shared.resolver.ResolverException;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.messaging.encoder.MessageEncodingException;
 import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
@@ -40,12 +37,14 @@ import org.opensaml.xmlsec.impl.BasicSignatureSigningParametersResolver;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import net.shibboleth.shared.collection.Pair;
-import net.shibboleth.shared.net.URLBuilder;
-import net.shibboleth.shared.resolver.CriteriaSet;
-import net.shibboleth.shared.resolver.ResolverException;
 import se.swedenconnect.opensaml.xmlsec.signature.support.SAMLObjectSigner;
+
+import java.net.MalformedURLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * A RequestHttpObject for sending using HTTP GET (redirect binding).
@@ -53,27 +52,26 @@ import se.swedenconnect.opensaml.xmlsec.signature.support.SAMLObjectSigner;
  * If signature credentials are supplied when creating the object the request will be signed.
  * </p>
  *
- * @author Martin Lindström (martin@idsec.se)
- *
  * @param <T> the type of the request
+ * @author Martin Lindström (martin@idsec.se)
  */
 public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HTTPRedirectDeflateEncoder
     implements RequestHttpObject<T> {
 
   /** Logging instance. */
-  private static final Logger logger = LoggerFactory.getLogger(RedirectRequestHttpObject.class);
+  private static final Logger log = LoggerFactory.getLogger(RedirectRequestHttpObject.class);
 
   /** The request. */
-  private T request;
+  private final T request;
 
   /** The URL to redirect to. */
-  private String sendUrl;
+  private final String sendUrl;
 
   /** The destination URL. */
-  private String destinationUrl;
+  private final String destinationUrl;
 
   /** HTTP headers. */
-  private Map<String, String> httpHeaders = new HashMap<>();
+  private final Map<String, String> httpHeaders = new HashMap<>();
 
   /** The query parameters. */
   private Map<String, String> requestParameters = null;
@@ -104,9 +102,9 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
    * @param signatureCredentials optional signature credentials
    * @param endpoint the endpoint where we send this request to
    * @param recipientMetadata the recipient metadata (may be null)
-   * @param defaultSignatureSigningConfiguration the default signature configuration for the application. If null, the
-   *          value returned from {@link SecurityConfigurationSupport#getGlobalSignatureSigningConfiguration()} will be
-   *          used
+   * @param defaultSignatureSigningConfiguration the default signature configuration for the application. If null,
+   *     the value returned from {@link SecurityConfigurationSupport#getGlobalSignatureSigningConfiguration()} will be
+   *     used
    * @throws MessageEncodingException for encoding errors
    * @throws SignatureException for signature errors
    */
@@ -134,7 +132,7 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
       if (peerConfig != null) {
         configs[pos++] = peerConfig;
       }
-      // The system wide configuration for signing.
+      // The system-wide configuration for signing.
       configs[pos++] = defaultSignatureSigningConfiguration != null
           ? defaultSignatureSigningConfiguration
           : SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration();
@@ -152,7 +150,7 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
         final SignatureSigningParameters parameters = signatureParametersResolver.resolveSingle(criteriaSet);
         messageContext.ensureSubcontext(SecurityParametersContext.class).setSignatureSigningParameters(parameters);
       }
-      catch (ResolverException e) {
+      catch (final ResolverException e) {
         throw new SignatureException(e);
       }
     }
@@ -164,7 +162,7 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
     this.sendUrl = this.buildRedirectURL(messageContext, endpoint, encodedMessage);
     this.destinationUrl = endpoint;
 
-    logger.trace("Redirect URL is {}", this.sendUrl);
+    log.trace("Redirect URL is {}", this.sendUrl);
 
     this.httpHeaders.put("Cache-control", "no-cache, no-store");
     this.httpHeaders.put("Pragma", "no-cache");

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestGenerationException.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestGenerationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Litsec AB
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package se.swedenconnect.opensaml.saml2.request;
 
 import se.swedenconnect.opensaml.common.LibraryVersion;
 
+import java.io.Serial;
+
 /**
  * Exception class for indicating errors during a request generation.
  *
@@ -25,6 +27,7 @@ import se.swedenconnect.opensaml.common.LibraryVersion;
 public class RequestGenerationException extends Exception {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /**
@@ -32,7 +35,7 @@ public class RequestGenerationException extends Exception {
    *
    * @param message the error message
    */
-  public RequestGenerationException(String message) {
+  public RequestGenerationException(final String message) {
     super(message);
   }
 
@@ -42,7 +45,7 @@ public class RequestGenerationException extends Exception {
    * @param message the error message
    * @param cause the cause of the error
    */
-  public RequestGenerationException(String message, Throwable cause) {
+  public RequestGenerationException(final String message, final Throwable cause) {
     super(message, cause);
   }
 

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestHttpObject.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestHttpObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package se.swedenconnect.opensaml.saml2.request;
 
-import java.util.Map;
-
 import org.opensaml.saml.saml2.core.RequestAbstractType;
+
+import java.util.Map;
 
 /**
  * Defines an interface that represents an object that holds data necessary for the SP application to transmit a request
@@ -32,9 +32,10 @@ public interface RequestHttpObject<T extends RequestAbstractType> {
    * <p>
    * For a redirect, this URL could look something like:
    * {@code https://www.theidp.com/auth?SAMLRequest=<encoded request>&RelayState=abcd}.
-   *
    * </p>
+   * <p>
    * <b>Note:</b> Additional query parameters may be added to the URL by the using system.
+   * </p>
    *
    * @return the URL to use when sending the user to the Identity Provider
    */
@@ -43,7 +44,7 @@ public interface RequestHttpObject<T extends RequestAbstractType> {
   /**
    * Returns the URL to where we are sending the request. If the method is "POST", this will be the same value as for
    * {@link #getSendUrl()}, and if the method is "GET", the value is just the destination and not the query parameters.
-   * 
+   *
    * @return the destination URL
    */
   String getDestinationUrl();

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestHttpObjectBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/RequestHttpObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/request/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/request/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes for handling SAML requests.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingException.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingException.java
@@ -15,12 +15,12 @@
  */
 package se.swedenconnect.opensaml.saml2.response;
 
-import java.util.Optional;
-
 import org.opensaml.saml.saml2.core.Response;
-
 import se.swedenconnect.opensaml.common.LibraryVersion;
 import se.swedenconnect.opensaml.common.utils.SerializableOpenSamlObject;
+
+import java.io.Serial;
+import java.util.Optional;
 
 /**
  * Exception class for the SAML response processor.
@@ -30,6 +30,7 @@ import se.swedenconnect.opensaml.common.utils.SerializableOpenSamlObject;
 public class ResponseProcessingException extends Exception {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /** The response. */
@@ -73,7 +74,7 @@ public class ResponseProcessingException extends Exception {
    */
   public ResponseProcessingException(final String message, final Throwable cause, final Response response) {
     super(message, cause);
-    this.response = response != null ? new SerializableOpenSamlObject<Response>(response) : null;
+    this.response = response != null ? new SerializableOpenSamlObject<>(response) : null;
   }
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingInput.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package se.swedenconnect.opensaml.saml2.response;
 
+import org.opensaml.saml.saml2.core.AuthnRequest;
+
 import java.security.cert.X509Certificate;
 import java.time.Instant;
-
-import org.opensaml.saml.saml2.core.AuthnRequest;
 
 /**
  * Represents the input passed along with a SAML Response to the {@link ResponseProcessor}.
@@ -46,14 +46,14 @@ public interface ResponseProcessingInput {
   /**
    * Returns the URL on which the response message was received.
    *
-   * @return the receive URL
+   * @return the reception URL
    */
   String getReceiveURL();
 
   /**
    * Returns the timestamp when the response was received.
    *
-   * @return the receive timestamp
+   * @return the reception timestamp
    */
   Instant getReceiveInstant();
 

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingResultImpl.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessingResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.response;
 
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
@@ -31,6 +25,12 @@ import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Subject;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Implementation of the {@code ResponseProcessingResult} interface.
@@ -62,7 +62,6 @@ public class ResponseProcessingResultImpl implements ResponseProcessingResult {
     return this.response;
   }
 
-
   /** {@inheritDoc} */
   @Override
   public String getResponseId() {
@@ -93,28 +92,28 @@ public class ResponseProcessingResultImpl implements ResponseProcessingResult {
     return Collections.unmodifiableList(this.assertion.getAttributeStatements().stream()
         .map(AttributeStatement::getAttributes)
         .findFirst()
-        .orElseGet(() -> Collections.emptyList()));
+        .orElseGet(Collections::emptyList));
   }
 
   /** {@inheritDoc} */
   @Override
   public String getAuthnContextClassUri() {
     return this.assertion.getAuthnStatements().stream()
-      .map(AuthnStatement::getAuthnContext)
-      .map(AuthnContext::getAuthnContextClassRef)
-      .map(AuthnContextClassRef::getURI)
-      .findFirst()
-      .orElse(null);
+        .map(AuthnStatement::getAuthnContext)
+        .map(AuthnContext::getAuthnContextClassRef)
+        .map(AuthnContextClassRef::getURI)
+        .findFirst()
+        .orElse(null);
   }
 
   /** {@inheritDoc} */
   @Override
   public Instant getAuthnInstant() {
 
-    final Instant authnInstant =  this.assertion.getAuthnStatements().stream()
+    final Instant authnInstant = this.assertion.getAuthnStatements().stream()
         .map(AuthnStatement::getAuthnInstant)
         .findFirst()
-        .orElseGet(() -> Instant.now());
+        .orElseGet(Instant::now);
 
     // We have already checked the validity of the authentication instant, but if it is
     // after the current time it means that it is within the allowed clock skew. If so,

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessor.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseStatusErrorException.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/ResponseStatusErrorException.java
@@ -15,16 +15,16 @@
  */
 package se.swedenconnect.opensaml.saml2.response;
 
-import java.util.Optional;
-
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
-
 import se.swedenconnect.opensaml.common.LibraryVersion;
 import se.swedenconnect.opensaml.common.utils.SerializableOpenSamlObject;
+
+import java.io.Serial;
+import java.util.Optional;
 
 /**
  * Exception that indicates a non-successful status code received in a Response message.
@@ -34,6 +34,7 @@ import se.swedenconnect.opensaml.common.utils.SerializableOpenSamlObject;
 public class ResponseStatusErrorException extends Exception {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /** The response. */
@@ -46,7 +47,7 @@ public class ResponseStatusErrorException extends Exception {
    */
   public ResponseStatusErrorException(final Response response) {
     super(statusToString(response.getStatus()));
-    this.response = new SerializableOpenSamlObject<Response>(response);
+    this.response = new SerializableOpenSamlObject<>(response);
 
     if (StatusCode.SUCCESS.equals(response.getStatus().getStatusCode().getValue())) {
       throw new IllegalArgumentException("Status is success - can not throw ResponseStatusErrorException");
@@ -71,7 +72,7 @@ public class ResponseStatusErrorException extends Exception {
       final Issuer issuerObj = (Issuer) XMLObjectSupport.buildXMLObject(Issuer.DEFAULT_ELEMENT_NAME);
       issuerObj.setValue(issuer);
       responseObj.setIssuer(issuerObj);
-      this.response = new SerializableOpenSamlObject<Response>(responseObj);
+      this.response = new SerializableOpenSamlObject<>(responseObj);
     }
     catch (final Exception e) {
       throw new RuntimeException(e);
@@ -127,7 +128,7 @@ public class ResponseStatusErrorException extends Exception {
    * @return a status string
    */
   public static String statusToString(final Status status) {
-    StringBuffer sb = new StringBuffer("Status: ");
+    final StringBuilder sb = new StringBuilder("Status: ");
     sb.append(status.getStatusCode().getValue());
     if (status.getStatusCode().getStatusCode() != null) {
       sb.append(", ").append(status.getStatusCode().getStatusCode().getValue());

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes for working with SAML responses.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/InMemoryReplayChecker.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/InMemoryReplayChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.response.replay;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
@@ -25,8 +22,12 @@ import org.opensaml.saml.saml2.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
- * An in-memory based message replay checker implementation. This is mainly for testing and simple mock implementations.
+ * An in-memory based message replay checker implementation. This is mainly for testing and simple mock
+ * implementations.
  *
  * @author Martin Lindström (martin@idsec.se)
  */
@@ -36,7 +37,7 @@ public class InMemoryReplayChecker implements MessageReplayChecker {
   private static final int MAX_SIZE = 1000;
 
   /** Logging instance. */
-  private final Logger log = LoggerFactory.getLogger(InMemoryReplayChecker.class);
+  private static final Logger log = LoggerFactory.getLogger(InMemoryReplayChecker.class);
 
   /** Number of milliseconds to keep elements in the replay cache - default is 5 minutes. */
   private long replayCacheExpiration = 300 * 1000L;
@@ -54,14 +55,14 @@ public class InMemoryReplayChecker implements MessageReplayChecker {
     else {
       if (System.currentTimeMillis() < e) {
         final String msg = String.format("Replay check of ID '%s' failed", id);
-        this.log.warn(msg);
+        log.warn(msg);
         throw new MessageReplayException(msg);
       }
       else {
         this.cache.remove(id);
       }
     }
-    this.log.debug("Message replay check of ID '{}' succeeded", id);
+    log.debug("Message replay check of ID '{}' succeeded", id);
     if (this.cache.size() > MAX_SIZE) {
       final long now = System.currentTimeMillis();
       this.cache.entrySet().removeIf(entry -> now > entry.getValue());

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayChecker.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayCheckerImpl.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayCheckerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 package se.swedenconnect.opensaml.saml2.response.replay;
 
-import java.time.Instant;
-import java.util.Optional;
-
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
@@ -25,6 +22,9 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.storage.ReplayCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Message replay checker implementation using OpenSAML's {@link ReplayCache} as an underlying cache.
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class MessageReplayCheckerImpl implements MessageReplayChecker {
 
   /** Logging instance. */
-  private final Logger log = LoggerFactory.getLogger(MessageReplayCheckerImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(MessageReplayCheckerImpl.class);
 
   /** The replay cache. */
   private ReplayCache replayCache;
@@ -63,7 +63,7 @@ public class MessageReplayCheckerImpl implements MessageReplayChecker {
   public void checkReplay(final String id) throws MessageReplayException {
     if (!this.replayCache.check(this.replayCacheName, id,
         Instant.ofEpochMilli(this.replayCacheExpiration + System.currentTimeMillis()))) {
-      String msg = String.format("Replay check of ID '%s' failed", id);
+      final String msg = String.format("Replay check of ID '%s' failed", id);
       log.warn(msg);
       throw new MessageReplayException(msg);
     }

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayException.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/MessageReplayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package se.swedenconnect.opensaml.saml2.response.replay;
 
 import se.swedenconnect.opensaml.common.LibraryVersion;
 
+import java.io.Serial;
+
 /**
  * Exception class that indicates a message replay attack.
  *
@@ -25,6 +27,7 @@ import se.swedenconnect.opensaml.common.LibraryVersion;
 public class MessageReplayException extends Exception {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/replay/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Support for handling message replay attacks.
  */

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/AbstractResponseValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/AbstractResponseValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  */
 package se.swedenconnect.opensaml.saml2.response.validation;
 
-import java.util.Collections;
-
 import org.opensaml.saml.common.assertion.ValidationContext;
 import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
 import org.opensaml.saml.saml2.core.AuthnRequest;
-
 import se.swedenconnect.opensaml.common.validation.AbstractValidationParametersBuilder;
 import se.swedenconnect.opensaml.common.validation.CoreValidatorParameters;
+
+import java.util.Collections;
 
 /**
  * Abstract builder class for building the {@link ValidationContext} object for use as validation input to the

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationException.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationException.java
@@ -16,9 +16,10 @@
 package se.swedenconnect.opensaml.saml2.response.validation;
 
 import org.opensaml.saml.saml2.core.Response;
-
 import se.swedenconnect.opensaml.common.LibraryVersion;
 import se.swedenconnect.opensaml.saml2.response.ResponseProcessingException;
+
+import java.io.Serial;
 
 /**
  * Exception class for response validation errors.
@@ -28,6 +29,7 @@ import se.swedenconnect.opensaml.saml2.response.ResponseProcessingException;
 public class ResponseValidationException extends ResponseProcessingException {
 
   /** For serializing. */
+  @Serial
   private static final long serialVersionUID = LibraryVersion.SERIAL_VERSION_UID;
 
   /**

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationParametersBuilder.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationSettings.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidationSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidator.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/ResponseValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  */
 package se.swedenconnect.opensaml.saml2.response.validation;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
-
+import net.shibboleth.shared.net.URIComparator;
+import net.shibboleth.shared.net.URIException;
+import net.shibboleth.shared.net.impl.BasicURLComparator;
 import org.apache.commons.lang3.StringUtils;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.common.assertion.ValidationContext;
@@ -33,14 +32,14 @@ import org.opensaml.xmlsec.signature.support.SignaturePrevalidator;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import net.shibboleth.shared.net.URIComparator;
-import net.shibboleth.shared.net.URIException;
-import net.shibboleth.shared.net.impl.BasicURLComparator;
 import se.swedenconnect.opensaml.common.validation.AbstractSignableObjectValidator;
 import se.swedenconnect.opensaml.common.validation.CoreValidatorParameters;
 import se.swedenconnect.opensaml.common.validation.ValidationSupport;
 import se.swedenconnect.opensaml.common.validation.ValidationSupport.ValidationResultException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Response validator that ensures that a {@code Response} element is valid according to the 2.0 SAML Core specification
@@ -75,7 +74,7 @@ import se.swedenconnect.opensaml.common.validation.ValidationSupport.ValidationR
 public class ResponseValidator extends AbstractSignableObjectValidator<Response> {
 
   /** Class logger. */
-  private final Logger log = LoggerFactory.getLogger(ResponseValidator.class);
+  private static final Logger log = LoggerFactory.getLogger(ResponseValidator.class);
 
   /** The URI comparator used when checking URL:s against each other. */
   private URIComparator uriComparator = new BasicURLComparator();
@@ -119,7 +118,7 @@ public class ResponseValidator extends AbstractSignableObjectValidator<Response>
       ValidationSupport.check(this.validateAssertions(response, context));
       ValidationSupport.check(this.validateExtensions(response, context));
     }
-    catch (ValidationResultException e) {
+    catch (final ValidationResultException e) {
       return e.getResult();
     }
 
@@ -234,7 +233,7 @@ public class ResponseValidator extends AbstractSignableObjectValidator<Response>
     }
     String expectedInResponseTo = (String) context.getStaticParameters().get(CoreValidatorParameters.AUTHN_REQUEST_ID);
     if (expectedInResponseTo == null) {
-      AuthnRequest authnRequest =
+      final AuthnRequest authnRequest =
           (AuthnRequest) context.getStaticParameters().get(CoreValidatorParameters.AUTHN_REQUEST);
       if (authnRequest != null) {
         expectedInResponseTo = authnRequest.getID();
@@ -286,7 +285,7 @@ public class ResponseValidator extends AbstractSignableObjectValidator<Response>
       catch (final URIException e) {
         final String msg = String.format(
             "Error when comparing Destination attribute (%s) with URL on which the response was received (%s) - %s",
-            response.getDestination(), receiveUrl, e.getMessage(), e);
+            response.getDestination(), receiveUrl, e.getMessage());
         context.getValidationFailureMessages().add(msg);
         return ValidationResult.INVALID;
       }
@@ -362,7 +361,7 @@ public class ResponseValidator extends AbstractSignableObjectValidator<Response>
       }
     }
     else {
-      if (response.getAssertions().size() > 0 || response.getEncryptedAssertions().size() > 0) {
+      if (!response.getAssertions().isEmpty() || !response.getEncryptedAssertions().isEmpty()) {
         context.getValidationFailureMessages()
             .add("Response message has failure status but contains assertions - invalid");
         return ValidationResult.INVALID;

--- a/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/package-info.java
+++ b/src/main/java/se/swedenconnect/opensaml/saml2/response/validation/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Support for validation of SAML response messages.
  */

--- a/src/main/resources/META-INF/services/org.opensaml.core.config.Initializer
+++ b/src/main/resources/META-INF/services/org.opensaml.core.config.Initializer
@@ -1,1 +1,16 @@
+#
+# Copyright 2016-2024 Sweden Connect
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 se.swedenconnect.opensaml.config.XMLObjectProviderInitializer

--- a/src/main/resources/shib-scope-config.xml
+++ b/src/main/resources/shib-scope-config.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<XMLTooling xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<XMLTooling xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
-  xmlns="http://www.opensaml.org/xmltooling-config" 
+  xmlns="http://www.opensaml.org/xmltooling-config"
   xsi:schemaLocation="http://www.opensaml.org/xmltooling-config ../../src/schema/xmltooling-config.xsd">
 
   <ObjectProviders>

--- a/src/test/java/se/swedenconnect/opensaml/common/LibraryVersionTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/common/LibraryVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,17 @@
  */
 package se.swedenconnect.opensaml.common;
 
-import java.util.Properties;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
 
 /**
  * Test cases for LibraryVersion.
  *
  * @author Martin Lindström
  */
-public class LibraryVersionTest {
+class LibraryVersionTest {
 
   private String version;
 
@@ -35,19 +35,21 @@ public class LibraryVersionTest {
 
     this.version = properties.getProperty("library.version");
     if (this.version.endsWith("-SNAPSHOT")) {
-      this.version = this.version.substring(0, version.length() - 9);
+      this.version = this.version.substring(0, this.version.length() - 9);
     }
   }
 
   @Test
-  public void testUid() {
-    Assertions.assertEquals(this.version.hashCode(), LibraryVersion.SERIAL_VERSION_UID);
+  void testUid() {
+    final String[] parts = this.version.split("\\.");
+    final String majorAndMinor = parts[0] + "." + parts[1];
+    Assertions.assertEquals(majorAndMinor.hashCode(), LibraryVersion.SERIAL_VERSION_UID);
   }
 
   @Test
-  public void testVersion() throws Exception {
+  void testVersion() {
     Assertions.assertEquals(this.version, LibraryVersion.getVersion(),
-        "Expected LibraryVersion.getVersion() to return " + version);
+        "Expected LibraryVersion.getVersion() to return " + this.version);
   }
 
 }

--- a/src/test/java/se/swedenconnect/opensaml/common/builder/AbstractSAMLObjectBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/common/builder/AbstractSAMLObjectBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Litsec AB
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ public class AbstractSAMLObjectBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testBuild() throws Exception {
-    StatusCodeBuilder builder = new StatusCodeBuilder();
-    StatusCode status = builder
+    final StatusCodeBuilder builder = new StatusCodeBuilder();
+    final StatusCode status = builder
         .value(StatusCode.REQUESTER)
         .statusCode(
           (new StatusCodeBuilder())
@@ -58,14 +58,14 @@ public class AbstractSAMLObjectBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testBuildFromTemplate() throws Exception {
-    StatusCode template = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
+    final StatusCode template = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
     template.setValue(StatusCode.REQUESTER);
-    StatusCode subCode = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
+    final StatusCode subCode = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
     subCode.setValue(StatusCode.AUTHN_FAILED);
     template.setStatusCode(subCode);
 
-    StatusCodeBuilder builder = new StatusCodeBuilder(template);
-    StatusCode status = builder.value(StatusCode.RESPONDER).build();
+    final StatusCodeBuilder builder = new StatusCodeBuilder(template);
+    final StatusCode status = builder.value(StatusCode.RESPONDER).build();
 
     Assertions.assertEquals(StatusCode.RESPONDER, status.getValue());
     Assertions.assertEquals(StatusCode.AUTHN_FAILED, status.getStatusCode().getValue());
@@ -77,18 +77,18 @@ public class AbstractSAMLObjectBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testBuildFromResource() throws Exception {
-    StatusCode template = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
+    final StatusCode template = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
     template.setValue(StatusCode.REQUESTER);
-    StatusCode subCode = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
+    final StatusCode subCode = (StatusCode) XMLObjectSupport.buildXMLObject(StatusCode.DEFAULT_ELEMENT_NAME);
     subCode.setValue(StatusCode.AUTHN_FAILED);
     template.setStatusCode(subCode);
 
     // Go to XML
-    Element element = XMLObjectSupport.marshall(template);
-    String xml = SerializeSupport.prettyPrintXML(element);
+    final Element element = XMLObjectSupport.marshall(template);
+    final String xml = SerializeSupport.prettyPrintXML(element);
 
-    StatusCodeBuilder builder = new StatusCodeBuilder(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
-    StatusCode status = builder.value(StatusCode.RESPONDER).build();
+    final StatusCodeBuilder builder = new StatusCodeBuilder(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    final StatusCode status = builder.value(StatusCode.RESPONDER).build();
 
     Assertions.assertEquals(StatusCode.RESPONDER, status.getValue());
     Assertions.assertEquals(StatusCode.AUTHN_FAILED, status.getStatusCode().getValue());
@@ -103,25 +103,25 @@ public class AbstractSAMLObjectBuilderTest extends OpenSAMLTestBase {
       super();
     }
 
-    public StatusCodeBuilder(InputStream resource) throws XMLParserException, UnmarshallingException {
+    public StatusCodeBuilder(final InputStream resource) throws XMLParserException, UnmarshallingException {
       super(resource);
     }
 
-    public StatusCodeBuilder(StatusCode template) throws MarshallingException, UnmarshallingException {
+    public StatusCodeBuilder(final StatusCode template) throws MarshallingException, UnmarshallingException {
       super(template);
     }
 
-    StatusCodeBuilder value(String value) {
+    StatusCodeBuilder value(final String value) {
       this.object().setValue(value);
       return this;
     }
 
-    StatusCodeBuilder statusCode(StatusCode statusCode) {
+    StatusCodeBuilder statusCode(final StatusCode statusCode) {
       this.object().setStatusCode(statusCode);
       return this;
     }
 
-    StatusCodeBuilder statusCode(String statusCode) {
+    StatusCodeBuilder statusCode(final String statusCode) {
       this.object().setStatusCode((new StatusCodeBuilder()).value(statusCode).build());
       return this;
     }

--- a/src/test/java/se/swedenconnect/opensaml/common/utils/LocalizedStringTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/common/utils/LocalizedStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/se/swedenconnect/opensaml/common/utils/SerializableOpenSamlObjectTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/common/utils/SerializableOpenSamlObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ public class SerializableOpenSamlObjectTest {
 
     private static final long serialVersionUID = -56880659229972600L;
 
-    private String text;
+    private final String text;
 
-    private SerializableOpenSamlObject<Issuer> issuer;
+    private final SerializableOpenSamlObject<Issuer> issuer;
 
     public TestObject(final String text, final Issuer issuer) {
       this.text = text;

--- a/src/test/java/se/swedenconnect/opensaml/common/validation/AbstractSignableObjectValidatorTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/common/validation/AbstractSignableObjectValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package se.swedenconnect.opensaml.common.validation;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -50,16 +51,16 @@ public class AbstractSignableObjectValidatorTest extends OpenSAMLTestBase {
 
   public static final String ISSUER_ENTITYID = "https://idp.svelegtest.se/idp";
 
-  private SignatureTrustEngine signatureTrustEngine;
+  private final SignatureTrustEngine signatureTrustEngine;
 
-  private SignaturePrevalidator signatureProfileValidator = new SAMLSignatureProfileValidator();
+  private final SignaturePrevalidator signatureProfileValidator = new SAMLSignatureProfileValidator();
 
   public AbstractSignableObjectValidatorTest() throws Exception {
-    X509Certificate cert = decodeCertificate(new ClassPathResource("/signed/signer.crt").getInputStream());
-    BasicX509Credential cred = new BasicX509Credential(cert);
+    final X509Certificate cert = decodeCertificate(new ClassPathResource("/signed/signer.crt").getInputStream());
+    final BasicX509Credential cred = new BasicX509Credential(cert);
     cred.setEntityId(ISSUER_ENTITYID);
 
-    CollectionCredentialResolver credentialResolver = new CollectionCredentialResolver(Arrays.asList(cred));
+    final CollectionCredentialResolver credentialResolver = new CollectionCredentialResolver(List.of(cred));
 
     this.signatureTrustEngine = new ExplicitKeySignatureTrustEngine(credentialResolver,
       DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
@@ -67,56 +68,56 @@ public class AbstractSignableObjectValidatorTest extends OpenSAMLTestBase {
 
   @Test
   public void testResponseSignatureValidation() throws Exception {
-    TestResponseValidator validator = new TestResponseValidator(this.signatureTrustEngine, this.signatureProfileValidator);
+    final TestResponseValidator validator = new TestResponseValidator(this.signatureTrustEngine, this.signatureProfileValidator);
 
-    Map<String, Object> staticPars = new HashMap<String, Object>();
+    final Map<String, Object> staticPars = new HashMap<String, Object>();
     staticPars.put(SAML2AssertionValidationParameters.SIGNATURE_REQUIRED, Boolean.TRUE);
     staticPars.put(SAML2AssertionValidationParameters.SIGNATURE_VALIDATION_CRITERIA_SET,
       new CriteriaSet(new EntityIdCriterion(ISSUER_ENTITYID), new UsageCriterion(UsageType.SIGNING)));
 
-    ValidationContext context = new ValidationContext(staticPars);
+    final ValidationContext context = new ValidationContext(staticPars);
 
-    Response response = unmarshall(new ClassPathResource("signed/signed-response.xml").getInputStream(), Response.class);
+    final Response response = unmarshall(new ClassPathResource("signed/signed-response.xml").getInputStream(), Response.class);
 
-    ValidationResult result = validator.validate(response, context);
+    final ValidationResult result = validator.validate(response, context);
     Assertions.assertEquals(ValidationResult.VALID, result);
   }
 
   @Test
   public void testResponseSignatureValidationFailureBadDigest() throws Exception {
-    TestResponseValidator validator = new TestResponseValidator(this.signatureTrustEngine, this.signatureProfileValidator);
+    final TestResponseValidator validator = new TestResponseValidator(this.signatureTrustEngine, this.signatureProfileValidator);
 
-    Map<String, Object> staticPars = new HashMap<String, Object>();
+    final Map<String, Object> staticPars = new HashMap<String, Object>();
     staticPars.put(SAML2AssertionValidationParameters.SIGNATURE_REQUIRED, Boolean.TRUE);
     staticPars.put(SAML2AssertionValidationParameters.SIGNATURE_VALIDATION_CRITERIA_SET,
       new CriteriaSet(new EntityIdCriterion(ISSUER_ENTITYID), new UsageCriterion(UsageType.SIGNING)));
 
-    ValidationContext context = new ValidationContext(staticPars);
+    final ValidationContext context = new ValidationContext(staticPars);
 
-    Response response = unmarshall(new ClassPathResource("signed/signed-baddigest-response.xml").getInputStream(), Response.class);
+    final Response response = unmarshall(new ClassPathResource("signed/signed-baddigest-response.xml").getInputStream(), Response.class);
 
-    ValidationResult result = validator.validate(response, context);
+    final ValidationResult result = validator.validate(response, context);
     Assertions.assertEquals(ValidationResult.INVALID, result);
   }
 
   private static class TestResponseValidator extends AbstractSignableObjectValidator<Response> {
 
-    public TestResponseValidator(SignatureTrustEngine trustEngine, SignaturePrevalidator signaturePrevalidator) {
+    public TestResponseValidator(final SignatureTrustEngine trustEngine, final SignaturePrevalidator signaturePrevalidator) {
       super(trustEngine, signaturePrevalidator);
     }
 
     @Override
-    public ValidationResult validate(Response object, ValidationContext context) {
+    public ValidationResult validate(final Response object, final ValidationContext context) {
       return this.validateSignature(object, context);
     }
 
     @Override
-    protected String getIssuer(Response signableObject) {
+    protected String getIssuer(final Response signableObject) {
       return signableObject.getIssuer().getValue();
     }
 
     @Override
-    protected String getID(Response signableObject) {
+    protected String getID(final Response signableObject) {
       return signableObject.getID();
     }
 

--- a/src/test/java/se/swedenconnect/opensaml/core/build/AuthnRequestBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/core/build/AuthnRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package se.swedenconnect.opensaml.core.build;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
@@ -50,7 +51,7 @@ public class AuthnRequestBuilderTest extends OpenSAMLTestBase {
     final Instant now = Instant.now();
     final String requesterID = "http://www.example.com/sp";
 
-    AuthnRequest request = AuthnRequestBuilder.builder()
+    final AuthnRequest request = AuthnRequestBuilder.builder()
       .assertionConsumerServiceURL(assertionConsumerServiceURL)
       .destination(destination)
       .forceAuthn(true)
@@ -82,7 +83,7 @@ public class AuthnRequestBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals(requesterID, request.getScoping().getRequesterIDs().get(0).getURI());
     Assertions.assertEquals(Boolean.TRUE, request.getNameIDPolicy().getAllowCreate());
     Assertions.assertEquals(AuthnContextComparisonTypeEnumeration.EXACT, request.getRequestedAuthnContext().getComparison());
-    Assertions.assertEquals(Arrays.asList(authnContext),
+    Assertions.assertEquals(List.of(authnContext),
       request.getRequestedAuthnContext().getAuthnContextClassRefs().stream()
         .map(AuthnContextClassRef::getURI)
         .collect(Collectors.toList()));

--- a/src/test/java/se/swedenconnect/opensaml/saml2/attribute/AttributeBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/attribute/AttributeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testCreateStringValueAttribute() {
-    Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
+    final Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
         .friendlyName(ATTRIBUTE_FRIENDLY_NAME_SN)
         .nameFormat(Attribute.URI_REFERENCE)
         .value("Eriksson")
@@ -59,7 +59,7 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testCreateMultipleStringValuesAttribute() {
-    Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_MAIL)
+    final Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_MAIL)
         .friendlyName(ATTRIBUTE_FRIENDLY_NAME_MAIL)
         .nameFormat(Attribute.URI_REFERENCE)
         .value("martin@litsec.se")
@@ -76,10 +76,10 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
   public void testCreateNonStringAttribute() {
 
     // We pretend that there is a attribute that holds a boolean ...
-    XSBoolean value = AttributeBuilder.createValueObject(XSBoolean.class);
+    final XSBoolean value = AttributeBuilder.createValueObject(XSBoolean.class);
     value.setValue(XSBooleanValue.valueOf("true"));
 
-    Attribute attribute = AttributeBuilder.builder("http://eid.litsec.se/types/boolean")
+    final Attribute attribute = AttributeBuilder.builder("http://eid.litsec.se/types/boolean")
         .friendlyName("booleanAttribute")
         .nameFormat(Attribute.URI_REFERENCE)
         .value(value)
@@ -94,7 +94,7 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testDefaultNameFormat() {
-    Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
+    final Attribute attribute = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
         .value("Eriksson")
         .build();
 
@@ -105,7 +105,7 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
 
   @Test
   public void testCreateValueObject() {
-    XSBase64Binary value = AttributeBuilder.createValueObject(XSBase64Binary.class);
+    final XSBase64Binary value = AttributeBuilder.createValueObject(XSBase64Binary.class);
     Assertions.assertEquals(XSBase64Binary.TYPE_NAME, value.getSchemaType());
     Assertions.assertEquals(AttributeValue.DEFAULT_ELEMENT_NAME, value.getElementQName());
   }
@@ -117,10 +117,10 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
       new AttributeBuilder((String)null);
       Assertions.fail("Expected IllegalArgumentException");
     }
-    catch (IllegalArgumentException e) {
+    catch (final IllegalArgumentException e) {
     }
 
-    AttributeBuilder builder = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
+    final AttributeBuilder builder = AttributeBuilder.builder(ATTRIBUTE_NAME_SN)
         .friendlyName(ATTRIBUTE_FRIENDLY_NAME_SN)
         .nameFormat(Attribute.URI_REFERENCE)
         .value("Eriksson");
@@ -131,7 +131,7 @@ public class AttributeBuilderTest extends OpenSAMLTestBase {
       builder.build();
       Assertions.fail("Expected RuntimeException");
     }
-    catch (RuntimeException e) {
+    catch (final RuntimeException e) {
     }
   }
 

--- a/src/test/java/se/swedenconnect/opensaml/saml2/attribute/AttributeUtilsTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/attribute/AttributeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
   @Test
   public void testGetAttributeStringValues() {
 
-    Attribute attribute = AttributeBuilder.builder(AttributeBuilderTest.ATTRIBUTE_NAME_MAIL)
+    final Attribute attribute = AttributeBuilder.builder(AttributeBuilderTest.ATTRIBUTE_NAME_MAIL)
       .friendlyName(AttributeBuilderTest.ATTRIBUTE_FRIENDLY_NAME_MAIL)
       .nameFormat(Attribute.URI_REFERENCE)
       .value("martin@litsec.se")
       .value("martin.lindstrom@litsec.se")
       .build();
 
-    List<String> values = AttributeUtils.getAttributeStringValues(attribute);
+    final List<String> values = AttributeUtils.getAttributeStringValues(attribute);
     Assertions.assertEquals(Arrays.asList("martin@litsec.se", "martin.lindstrom@litsec.se"), values);
 
     // Using the AttributeUtils.getAttributeStringValue method only gives the first value.
@@ -59,59 +59,59 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
   @Test
   public void testGetAttributeStringValue() {
 
-    Attribute attribute = AttributeBuilder.builder(AttributeBuilderTest.ATTRIBUTE_NAME_SN)
+    final Attribute attribute = AttributeBuilder.builder(AttributeBuilderTest.ATTRIBUTE_NAME_SN)
       .friendlyName(AttributeBuilderTest.ATTRIBUTE_FRIENDLY_NAME_SN)
       .nameFormat(Attribute.URI_REFERENCE)
       .value("Eriksson")
       .build();
 
-    String value = AttributeUtils.getAttributeStringValue(attribute);
+    final String value = AttributeUtils.getAttributeStringValue(attribute);
     Assertions.assertEquals("Eriksson", value);
 
     // Using the AttributeUtils.getAttributeStringValues method gives a list with one element.
-    Assertions.assertEquals(Arrays.asList("Eriksson"), AttributeUtils.getAttributeStringValues(attribute));
+    Assertions.assertEquals(List.of("Eriksson"), AttributeUtils.getAttributeStringValues(attribute));
   }
 
   @Test
   public void testGetAttributeStringValueNoType() throws Exception {
-    String xml = "<saml2:Attribute FriendlyName=\"sn\" Name=\"urn:oid:2.5.4.4\" " +
+    final String xml = "<saml2:Attribute FriendlyName=\"sn\" Name=\"urn:oid:2.5.4.4\" " +
         "NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
         "<saml2:AttributeValue>Eriksson</saml2:AttributeValue>" +
         "</saml2:Attribute>";
 
-    Attribute attribute = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
+    final Attribute attribute = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
 
-    String value = AttributeUtils.getAttributeStringValue(attribute);
+    final String value = AttributeUtils.getAttributeStringValue(attribute);
     Assertions.assertEquals("Eriksson", value);
 
     // Using the AttributeUtils.getAttributeStringValues method gives a list with one element.
-    Assertions.assertEquals(Arrays.asList("Eriksson"), AttributeUtils.getAttributeStringValues(attribute));
+    Assertions.assertEquals(List.of("Eriksson"), AttributeUtils.getAttributeStringValues(attribute));
   }
 
   @Test
   public void testGetAttributeValueBoolean() throws Exception {
-    XSBoolean bool = AttributeBuilder.createValueObject(XSBoolean.class);
+    final XSBoolean bool = AttributeBuilder.createValueObject(XSBoolean.class);
     bool.setValue(XSBooleanValue.valueOf("true"));
 
-    Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/bool")
+    final Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/bool")
       .friendlyName("LitsecBool")
       .nameFormat(Attribute.URI_REFERENCE)
       .value(bool)
       .build();
 
-    XSBoolean value = AttributeUtils.getAttributeValue(attribute, XSBoolean.class);
+    final XSBoolean value = AttributeUtils.getAttributeValue(attribute, XSBoolean.class);
     Assertions.assertNotNull(value);
     Assertions.assertTrue(value.getValue().getValue());
 
     // Try the same, but with no xsi:type declaration
     //
-    String xml = "<saml2:Attribute FriendlyName=\"LitsecBool\" Name=\"http://id.litsec.se/attr/bool\" " +
+    final String xml = "<saml2:Attribute FriendlyName=\"LitsecBool\" Name=\"http://id.litsec.se/attr/bool\" " +
         "NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\"> " +
         "<saml2:AttributeValue>true</saml2:AttributeValue> " +
         "</saml2:Attribute>";
 
-    Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
-    XSBoolean value2 = AttributeUtils.getAttributeValue(attribute2, XSBoolean.class);
+    final Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
+    final XSBoolean value2 = AttributeUtils.getAttributeValue(attribute2, XSBoolean.class);
     Assertions.assertNotNull(value2);
     Assertions.assertTrue(value2.getValue().getValue());
 
@@ -121,27 +121,27 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
 
   @Test
   public void testGetAttributeValueInteger() throws Exception {
-    XSInteger integer = AttributeBuilder.createValueObject(XSInteger.class);
+    final XSInteger integer = AttributeBuilder.createValueObject(XSInteger.class);
     integer.setValue(42);
 
-    Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/int")
+    final Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/int")
       .friendlyName("Litsecint")
       .nameFormat(Attribute.URI_REFERENCE)
       .value(integer)
       .build();
 
-    XSInteger value = AttributeUtils.getAttributeValue(attribute, XSInteger.class);
+    final XSInteger value = AttributeUtils.getAttributeValue(attribute, XSInteger.class);
     Assertions.assertNotNull(value);
     Assertions.assertEquals(42, value.getValue().intValue());
 
     // Try the same, but with no xsi:type declaration
     //
-    String xml = "<saml2:Attribute FriendlyName=\"Litsecint\"  Name=\"http://id.litsec.se/attr/int\" " +
+    final String xml = "<saml2:Attribute FriendlyName=\"Litsecint\"  Name=\"http://id.litsec.se/attr/int\" " +
         "NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\"> " +
         "<saml2:AttributeValue>42</saml2:AttributeValue> </saml2:Attribute>";
 
-    Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
-    XSInteger value2 = AttributeUtils.getAttributeValue(attribute2, XSInteger.class);
+    final Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
+    final XSInteger value2 = AttributeUtils.getAttributeValue(attribute2, XSInteger.class);
     Assertions.assertNotNull(value2);
     Assertions.assertEquals(42, value2.getValue().intValue());
 
@@ -152,28 +152,28 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
   @Test
   public void testGetAttributeValueDateTime() throws Exception {
 
-    Instant date = Instant.parse("2018-12-10T15:10:21Z");
-    XSDateTime xmlDate = AttributeBuilder.createValueObject(XSDateTime.class);
+    final Instant date = Instant.parse("2018-12-10T15:10:21Z");
+    final XSDateTime xmlDate = AttributeBuilder.createValueObject(XSDateTime.class);
     xmlDate.setValue(date);
 
-    Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/date")
+    final Attribute attribute = AttributeBuilder.builder("http://id.litsec.se/attr/date")
       .friendlyName("LitsecDate")
       .nameFormat(Attribute.URI_REFERENCE)
       .value(xmlDate)
       .build();
 
-    XSDateTime value = AttributeUtils.getAttributeValue(attribute, XSDateTime.class);
+    final XSDateTime value = AttributeUtils.getAttributeValue(attribute, XSDateTime.class);
     Assertions.assertNotNull(value);
     Assertions.assertEquals(date, value.getValue());
 
     // Try the same, but with no xsi:type declaration
     //
-    String xml = "<saml2:Attribute FriendlyName=\"LitsecDate\" Name=\"http://id.litsec.se/attr/date\" " +
+    final String xml = "<saml2:Attribute FriendlyName=\"LitsecDate\" Name=\"http://id.litsec.se/attr/date\" " +
         "NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\"> " +
         "<saml2:AttributeValue>2018-12-10T15:10:21.000Z</saml2:AttributeValue> </saml2:Attribute>";
 
-    Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
-    XSDateTime value2 = AttributeUtils.getAttributeValue(attribute2, XSDateTime.class);
+    final Attribute attribute2 = unmarshall(new ByteArrayInputStream(xml.getBytes()), Attribute.class);
+    final XSDateTime value2 = AttributeUtils.getAttributeValue(attribute2, XSDateTime.class);
     Assertions.assertNotNull(value2);
     Assertions.assertEquals(date, value2.getValue());
 
@@ -192,18 +192,18 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
       .value("martin.lindstrom@litsec.se")
       .build();
 
-    List<XSString> values = AttributeUtils.getAttributeValues(attribute, XSString.class);
+    final List<XSString> values = AttributeUtils.getAttributeValues(attribute, XSString.class);
     Assertions.assertTrue(values.size() == 2);
     Assertions.assertEquals(Arrays.asList("martin@litsec.se", "martin.lindstrom@litsec.se"),
       values.stream()
-        .filter(a -> XSString.class.isInstance(a))
+        .filter(a -> a instanceof XSString)
         .map(XSString.class::cast)
         .map(s -> s.getValue())
         .collect(Collectors.toList()));
 
-    XSBoolean value1 = AttributeBuilder.createValueObject(XSBoolean.class);
+    final XSBoolean value1 = AttributeBuilder.createValueObject(XSBoolean.class);
     value1.setValue(XSBooleanValue.valueOf("true"));
-    XSBoolean value2 = AttributeBuilder.createValueObject(XSBoolean.class);
+    final XSBoolean value2 = AttributeBuilder.createValueObject(XSBoolean.class);
     value2.setValue(XSBooleanValue.valueOf("false"));
 
     attribute = AttributeBuilder.builder("http://eid.litsec.se/types/boolean")
@@ -213,11 +213,11 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
       .value(value2)
       .build();
 
-    List<XSBoolean> bvalues = AttributeUtils.getAttributeValues(attribute, XSBoolean.class);
+    final List<XSBoolean> bvalues = AttributeUtils.getAttributeValues(attribute, XSBoolean.class);
     Assertions.assertTrue(values.size() == 2);
     Assertions.assertEquals(Arrays.asList(Boolean.TRUE, Boolean.FALSE),
       bvalues.stream()
-        .filter(a -> XSBoolean.class.isInstance(a))
+        .filter(a -> a instanceof XSBoolean)
         .map(XSBoolean.class::cast)
         .map(b -> b.getValue().getValue())
         .collect(Collectors.toList()));
@@ -232,10 +232,10 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
       .value("Eriksson")
       .build();
 
-    XSString value = AttributeUtils.getAttributeValue(attribute, XSString.class);
+    final XSString value = AttributeUtils.getAttributeValue(attribute, XSString.class);
     Assertions.assertEquals("Eriksson", value.getValue());
 
-    XSBoolean bvalue = AttributeBuilder.createValueObject(XSBoolean.class);
+    final XSBoolean bvalue = AttributeBuilder.createValueObject(XSBoolean.class);
     bvalue.setValue(XSBooleanValue.valueOf("true"));
 
     attribute = AttributeBuilder.builder("http://eid.litsec.se/types/boolean")
@@ -244,14 +244,14 @@ public class AttributeUtilsTest extends OpenSAMLTestBase {
       .value(bvalue)
       .build();
 
-    XSBoolean b = AttributeUtils.getAttributeValue(attribute, XSBoolean.class);
+    final XSBoolean b = AttributeUtils.getAttributeValue(attribute, XSBoolean.class);
     Assertions.assertEquals(Boolean.TRUE, b.getValue().getValue());
   }
 
   @Test
   public void testGetAttribute() {
 
-    List<Attribute> attributes = Arrays.asList(
+    final List<Attribute> attributes = Arrays.asList(
       AttributeBuilder.builder(AttributeBuilderTest.ATTRIBUTE_NAME_MAIL)
         .value("martin@litsec.se")
         .value("martin.lindstrom@litsec.se")

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityDescriptorBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/EntityDescriptorBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,9 +74,9 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
   public void testBuildSpMetadata() throws Exception {
 
     final String metadataId = "MLoeU7ALIHTZ61ibqZdJ";
-    Instant validUntil = Instant.now();
+    final Instant validUntil = Instant.now();
     validUntil.plus(7, ChronoUnit.DAYS);
-    long cacheDuration = 3600000L;
+    final long cacheDuration = 3600000L;
 
     final DigestMethod[] digestMethods = {
         DigestMethodBuilder.builder().algorithm(SignatureConstants.ALGO_ID_DIGEST_SHA256).build(),
@@ -167,7 +167,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
       .telephoneNumbers("+46 (0)70 361 98 80")
       .build();
 
-    EntityDescriptor ed = EntityDescriptorBuilder.builder()
+    final EntityDescriptor ed = EntityDescriptorBuilder.builder()
       .entityID(SP_ENTITY_ID)
       .id(metadataId)
       .cacheDuration(cacheDuration)
@@ -231,9 +231,9 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals((Long) cacheDuration, (Long) ed.getCacheDuration().toMillis());
     Assertions.assertEquals(validUntil.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), ed.getValidUntil().toEpochMilli());
 
-    EntityAttributes entityAttributes = EntityDescriptorUtils.getMetadataExtension(ed.getExtensions(), EntityAttributes.class);
+    final EntityAttributes entityAttributes = EntityDescriptorUtils.getMetadataExtension(ed.getExtensions(), EntityAttributes.class);
     Assertions.assertNotNull(entityAttributes);
-    Attribute entityCategoryAttribute = AttributeUtils.getAttribute(
+    final Attribute entityCategoryAttribute = AttributeUtils.getAttribute(
       AttributeConstants.ENTITY_CATEGORY_ATTRIBUTE_NAME, entityAttributes.getAttributes());
     Assertions.assertNotNull(entityCategoryAttribute);
     Assertions.assertEquals(Arrays.asList(entityCategories), AttributeUtils.getAttributeStringValues(entityCategoryAttribute));
@@ -244,17 +244,17 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals(2, EntityDescriptorUtils.getSigningMethods(ed).size());
     Assertions.assertTrue(ed.getExtensions().getUnknownXMLObjects(SigningMethod.DEFAULT_ELEMENT_NAME).isEmpty());
 
-    List<DigestMethod> digestList = EntityDescriptorUtils.getDigestMethods(ed);
+    final List<DigestMethod> digestList = EntityDescriptorUtils.getDigestMethods(ed);
     Assertions.assertEquals(digestMethods[0].getAlgorithm(), digestList.get(0).getAlgorithm());
     Assertions.assertEquals(digestMethods[1].getAlgorithm(), digestList.get(1).getAlgorithm());
     Assertions.assertEquals(digestMethods[2].getAlgorithm(), digestList.get(2).getAlgorithm());
 
-    SPSSODescriptor ssoDescriptor = ed.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
+    final SPSSODescriptor ssoDescriptor = ed.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
 
     Assertions.assertEquals(2, ssoDescriptor.getExtensions().getUnknownXMLObjects(SigningMethod.DEFAULT_ELEMENT_NAME).size());
     Assertions.assertTrue(ssoDescriptor.getExtensions().getUnknownXMLObjects(DigestMethod.DEFAULT_ELEMENT_NAME).isEmpty());
 
-    List<SigningMethod> signingList = EntityDescriptorUtils.getSigningMethods(ed);
+    final List<SigningMethod> signingList = EntityDescriptorUtils.getSigningMethods(ed);
     Assertions.assertEquals(signingMethods[0].getAlgorithm(), signingList.get(0).getAlgorithm());
     Assertions.assertEquals(signingMethods[0].getMinKeySize(), signingList.get(0).getMinKeySize());
     Assertions.assertEquals(signingMethods[1].getAlgorithm(), signingList.get(1).getAlgorithm());
@@ -262,7 +262,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertTrue(ssoDescriptor.isAuthnRequestsSigned());
     Assertions.assertTrue(ssoDescriptor.getWantAssertionsSigned());
 
-    UIInfo uiInfo = EntityDescriptorUtils.getMetadataExtension(ssoDescriptor.getExtensions(), UIInfo.class);
+    final UIInfo uiInfo = EntityDescriptorUtils.getMetadataExtension(ssoDescriptor.getExtensions(), UIInfo.class);
     Assertions.assertNotNull(uiInfo);
     Assertions.assertEquals(Arrays.asList(uiDisplayNames),
       uiInfo.getDisplayNames().stream().map(dn -> new LocalizedString(dn.getValue(), dn.getXMLLang())).collect(Collectors.toList()));
@@ -277,7 +277,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals(Arrays.asList(uiLogos).stream().map(l -> l.getWidth()).collect(Collectors.toList()),
       uiInfo.getLogos().stream().map(l -> l.getWidth()).collect(Collectors.toList()));
 
-    List<DiscoveryResponse> discoResponses =
+    final List<DiscoveryResponse> discoResponses =
         EntityDescriptorUtils.getMetadataExtensions(ssoDescriptor.getExtensions(), DiscoveryResponse.class);
     Assertions.assertTrue(discoResponses.size() == 2);
     Assertions.assertEquals(1, (int) discoResponses.get(0).getIndex());
@@ -329,7 +329,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals(Arrays.asList(organizationDisplayNames),
       ed.getOrganization().getDisplayNames().stream().map(n -> new LocalizedString(n.getValue(), n.getXMLLang())).collect(Collectors
         .toList()));
-    Assertions.assertEquals(Arrays.asList(organizationURL),
+    Assertions.assertEquals(List.of(organizationURL),
       ed.getOrganization().getURLs().stream().map(n -> new LocalizedString(n.getURI(), n.getXMLLang())).collect(Collectors.toList()));
 
     Assertions.assertEquals(2, ed.getContactPersons().size());
@@ -339,9 +339,9 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
       Assertions.assertEquals("Litsec AB", ed.getContactPersons().get(i).getCompany().getValue());
       Assertions.assertEquals("Martin", ed.getContactPersons().get(i).getGivenName().getValue());
       Assertions.assertEquals("Lindström", ed.getContactPersons().get(i).getSurName().getValue());
-      Assertions.assertEquals(Arrays.asList("martin.lindstrom@litsec.se"),
+      Assertions.assertEquals(List.of("martin.lindstrom@litsec.se"),
         ed.getContactPersons().get(i).getEmailAddresses().stream().map(m -> m.getURI()).collect(Collectors.toList()));
-      Assertions.assertEquals(Arrays.asList("+46 (0)70 361 98 80"),
+      Assertions.assertEquals(List.of("+46 (0)70 361 98 80"),
         ed.getContactPersons().get(i).getTelephoneNumbers().stream().map(t -> t.getValue()).collect(Collectors.toList()));
     }
   }
@@ -353,9 +353,9 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
   public void testBuildIdpMetadata() throws Exception {
 
     final String metadataId = "MLoeU7ALIHTZ61ibqZdJ";
-    Instant validUntil = Instant.now();
+    final Instant validUntil = Instant.now();
     validUntil.plus(7, ChronoUnit.DAYS);
-    long cacheDuration = 3600000L;
+    final long cacheDuration = 3600000L;
 
     final String[] assuranceCertificationUris = {
         "http://id.elegnamnden.se/loa/1.0/loa2",
@@ -411,7 +411,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
       .emailAddresses("stefan@aaa-sec.com")
       .build();
 
-    EntityDescriptor ed = EntityDescriptorBuilder.builder()
+    final EntityDescriptor ed = EntityDescriptorBuilder.builder()
       .entityID(SP_ENTITY_ID)
       .id(metadataId)
       .cacheDuration(cacheDuration)
@@ -454,31 +454,31 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
         ContactPersonBuilder.builder(contactPersonTemplate).type(ContactPersonTypeEnumeration.SUPPORT).build())
       .build();
 
-    Element elm = XMLObjectSupport.marshall(ed);
+    final Element elm = XMLObjectSupport.marshall(ed);
     System.out.println(SerializeSupport.prettyPrintXML(elm));
 
     Assertions.assertEquals(metadataId, ed.getID());
     Assertions.assertEquals((Long) cacheDuration, (Long) ed.getCacheDuration().toMillis());
     Assertions.assertEquals(validUntil.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), ed.getValidUntil().toEpochMilli());
 
-    EntityAttributes entityAttributes = EntityDescriptorUtils.getMetadataExtension(ed.getExtensions(), EntityAttributes.class);
+    final EntityAttributes entityAttributes = EntityDescriptorUtils.getMetadataExtension(ed.getExtensions(), EntityAttributes.class);
     Assertions.assertNotNull(entityAttributes);
 
-    Attribute entityCategoryAttribute = AttributeUtils.getAttribute(
+    final Attribute entityCategoryAttribute = AttributeUtils.getAttribute(
       AttributeConstants.ENTITY_CATEGORY_ATTRIBUTE_NAME, entityAttributes.getAttributes());
     Assertions.assertNotNull(entityCategoryAttribute);
     Assertions.assertEquals(Arrays.asList(entityCategories), AttributeUtils.getAttributeStringValues(entityCategoryAttribute));
 
-    Attribute assuranceCertificationAttribute = AttributeUtils.getAttribute(
+    final Attribute assuranceCertificationAttribute = AttributeUtils.getAttribute(
       AttributeConstants.ASSURANCE_CERTIFICATION_ATTRIBUTE_NAME, entityAttributes.getAttributes());
     Assertions.assertNotNull(assuranceCertificationAttribute);
     Assertions.assertEquals(Arrays.asList(assuranceCertificationUris), AttributeUtils.getAttributeStringValues(assuranceCertificationAttribute));
 
-    IDPSSODescriptor ssoDescriptor = ed.getIDPSSODescriptor(SAMLConstants.SAML20P_NS);
+    final IDPSSODescriptor ssoDescriptor = ed.getIDPSSODescriptor(SAMLConstants.SAML20P_NS);
 
     Assertions.assertEquals(Boolean.TRUE, ssoDescriptor.getWantAuthnRequestsSigned());
 
-    UIInfo uiInfo = EntityDescriptorUtils.getMetadataExtension(ssoDescriptor.getExtensions(), UIInfo.class);
+    final UIInfo uiInfo = EntityDescriptorUtils.getMetadataExtension(ssoDescriptor.getExtensions(), UIInfo.class);
     Assertions.assertNotNull(uiInfo);
     Assertions.assertEquals(Arrays.asList(uiDisplayNames),
       uiInfo.getDisplayNames().stream().map(dn -> new LocalizedString(dn.getValue(), dn.getXMLLang())).collect(Collectors.toList()));
@@ -515,7 +515,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     Assertions.assertEquals(Arrays.asList(organizationDisplayNames),
       ed.getOrganization().getDisplayNames().stream().map(n -> new LocalizedString(n.getValue(), n.getXMLLang())).collect(Collectors
         .toList()));
-    Assertions.assertEquals(Arrays.asList(organizationURL),
+    Assertions.assertEquals(List.of(organizationURL),
       ed.getOrganization().getURLs().stream().map(n -> new LocalizedString(n.getURI(), n.getXMLLang())).collect(Collectors.toList()));
 
     Assertions.assertEquals(2, ed.getContactPersons().size());
@@ -524,7 +524,7 @@ public class EntityDescriptorBuilderTest extends OpenSAMLTestBase {
     for (int i = 0; i < 2; i++) {
       Assertions.assertEquals("E-legitimationsnämnden", ed.getContactPersons().get(i).getCompany().getValue());
       Assertions
-          .assertEquals(Arrays.asList("stefan@aaa-sec.com"),
+          .assertEquals(List.of("stefan@aaa-sec.com"),
         ed.getContactPersons().get(i).getEmailAddresses().stream().map(m -> m.getURI()).collect(Collectors.toList()));
     }
   }

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/LogoBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/LogoBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/ScopeBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/ScopeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/UIInfoBuilderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/build/UIInfoBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
   static {
     KEYWORDS = new HashMap<String, List<String>>();
     KEYWORDS.put(Locale.ENGLISH.getLanguage(), Arrays.asList("authentication", "SAML", "two-factor"));
-    KEYWORDS.put("sv", Arrays.asList("legitimering"));
+    KEYWORDS.put("sv", List.of("legitimering"));
   }
 
   /**
@@ -78,7 +78,7 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
   @Test
   public void testCreateFull() throws Exception {
 
-    UIInfo uiInfo = (new UIInfoBuilder())
+    final UIInfo uiInfo = (new UIInfoBuilder())
       .displayNames(DISPLAY_NAMES)
       .keywords(KEYWORDS)
       .descriptions(DESCRIPTIONS)
@@ -99,21 +99,21 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
   @Test
   public void testSimple() throws Exception {
 
-    LocalizedString[] displayNames = new LocalizedString[] {
+    final LocalizedString[] displayNames = new LocalizedString[] {
         new LocalizedString("Litsec legitimering", "sv"),
         new LocalizedString("Litsec authentication", Locale.ENGLISH) };
 
-    String[] keywords = new String[] { "authentication", "SAML", "two-factor" };
+    final String[] keywords = new String[] { "authentication", "SAML", "two-factor" };
 
-    LocalizedString description = new LocalizedString("Litsecs tjänst för legitimering", "sv");
+    final LocalizedString description = new LocalizedString("Litsecs tjänst för legitimering", "sv");
 
-    Logo[] logos = new Logo[] {
+    final Logo[] logos = new Logo[] {
         createLogo("http://www.litsec.se/logo-sv.jpg", null, 16, 16),
         createLogo("http://www.litsec.se/logo-sv-large.jpg", null, 200, 200) };
 
-    LocalizedString informationURL = new LocalizedString("http://www.litsec.se", "sv");
+    final LocalizedString informationURL = new LocalizedString("http://www.litsec.se", "sv");
 
-    UIInfo uiInfo = (new UIInfoBuilder())
+    final UIInfo uiInfo = (new UIInfoBuilder())
       .displayNames(displayNames)
       .keywords(keywords)
       .descriptions(description)
@@ -125,8 +125,8 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
         informationURL }, null);
   }
 
-  public static Logo createLogo(String url, String language, Integer height, Integer width) {
-    Logo logo = (Logo) XMLObjectSupport.buildXMLObject(Logo.DEFAULT_ELEMENT_NAME);
+  public static Logo createLogo(final String url, final String language, final Integer height, final Integer width) {
+    final Logo logo = (Logo) XMLObjectSupport.buildXMLObject(Logo.DEFAULT_ELEMENT_NAME);
     logo.setURI(url);
     logo.setXMLLang(language);
     logo.setHeight(height);
@@ -134,8 +134,8 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
     return logo;
   }
 
-  public static void assertUIInfo(UIInfo uiInfo, LocalizedString[] displayNames, Map<String, List<String>> keywords, String[] keywordsArray,
-      LocalizedString[] descriptions, Logo[] logos, LocalizedString[] informationURLs, LocalizedString[] privayStatementURLs) {
+  public static void assertUIInfo(final UIInfo uiInfo, final LocalizedString[] displayNames, final Map<String, List<String>> keywords, final String[] keywordsArray,
+      final LocalizedString[] descriptions, final Logo[] logos, final LocalizedString[] informationURLs, final LocalizedString[] privayStatementURLs) {
 
     Assertions.assertEquals(displayNames != null ? displayNames.length : 0, uiInfo.getDisplayNames().size());
     for (int i = 0; i < uiInfo.getDisplayNames().size(); i++) {
@@ -145,8 +145,8 @@ public class UIInfoBuilderTest extends OpenSAMLTestBase {
 
     if (keywords != null) {
       Assertions.assertEquals(keywords.keySet().size(), uiInfo.getKeywords().size());
-      for (Keywords kw : uiInfo.getKeywords()) {
-        List<String> words = keywords.get(kw.getXMLLang());
+      for (final Keywords kw : uiInfo.getKeywords()) {
+        final List<String> words = keywords.get(kw.getXMLLang());
         Assertions.assertNotNull(words);
         Assertions.assertEquals(words, kw.getKeywords());
       }

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/AdBugTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/AdBugTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2024 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.opensaml.saml2.metadata.provider;
+
+import org.junit.jupiter.api.Test;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import se.swedenconnect.opensaml.OpenSAMLTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Testing that our workaround to only save SP:s and IDP:s avoids the bug somewhere deep down in OpenSAML when unknown
+ * role descriptors are present.
+ *
+ * @author Martin Lindström
+ */
+class AdBugTest extends OpenSAMLTestBase {
+
+  @Test
+  void testKeepOnlySsoDescriptors() throws Exception {
+    final Resource resource = new ClassPathResource("federationmetadata.xml");
+    final XMLObject object = XMLObjectSupport.unmarshallFromInputStream(
+        XMLObjectProviderRegistrySupport.getParserPool(), resource.getInputStream());
+    final StaticMetadataProvider p = new StaticMetadataProvider((EntityDescriptor) object);
+    p.initialize();
+
+    assertEquals(1, p.getServiceProviders().size());
+    assertEquals(1, p.getIdentityProviders().size());
+
+    final EntityDescriptor sp = p.getEntityDescriptor("http://fstest.example.se/adfs/services/trust",
+        SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    assertDoesNotThrow(() -> XMLObjectSupport.cloneXMLObject(sp));
+  }
+
+  @Test
+  void testKeepAllDescriptors() throws Exception {
+    final Resource resource = new ClassPathResource("federationmetadata.xml");
+    final XMLObject object = XMLObjectSupport.unmarshallFromInputStream(
+        XMLObjectProviderRegistrySupport.getParserPool(), resource.getInputStream());
+    final StaticMetadataProvider p = new StaticMetadataProvider((EntityDescriptor) object);
+    p.setKeepOnlySpAndIdps(false);
+    p.initialize();
+
+    final EntityDescriptor sp = p.getEntityDescriptor("http://fstest.example.se/adfs/services/trust",
+        SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+    // Clone fails -> OpenSAML bug ...
+    assertThrows(ClassCastException.class, () -> XMLObjectSupport.cloneXMLObject(sp));
+  }
+}

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/BaseMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/BaseMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package se.swedenconnect.opensaml.saml2.metadata.provider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -155,7 +156,7 @@ public abstract class BaseMetadataProviderTest extends OpenSAMLTestBase {
       provider.initialize();
       final Element dom = provider.getMetadataDOM();
       final EntitiesDescriptor ed =
-          EntitiesDescriptor.class.cast(XMLObjectSupport.getUnmarshaller(dom).unmarshall(dom));
+          (EntitiesDescriptor) XMLObjectSupport.getUnmarshaller(dom).unmarshall(dom);
       for (final EntityDescriptor e : ed.getEntityDescriptors()) {
         final EntityDescriptor e2 = provider.getEntityDescriptor(e.getEntityID());
         Assertions.assertNotNull(e2, String.format("EntityDescriptor for '%s' was not found", e.getEntityID()));
@@ -220,7 +221,7 @@ public abstract class BaseMetadataProviderTest extends OpenSAMLTestBase {
     final AbstractMetadataProvider provider =
         this.createMetadataProvider(new ClassPathResource("/metadata/sveleg-fedtest.xml"));
     try {
-      provider.setInclusionPredicates(Arrays.asList(includePredicate));
+      provider.setInclusionPredicates(Collections.singletonList(includePredicate));
       provider.initialize();
       final List<EntityDescriptor> list = new ArrayList<>();
       final Iterable<EntityDescriptor> i = provider.iterator();

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/CompositeMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/CompositeMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ public class CompositeMetadataProviderTest extends OpenSAMLTestBase {
    */
   @BeforeAll
   public static void setup() throws Exception {
-    Resource entireMetadata = new ClassPathResource("/metadata/sveleg-fedtest.xml");
-    Element entireMetadataDOM = XMLObjectProviderRegistrySupport.getParserPool()
+    final Resource entireMetadata = new ClassPathResource("/metadata/sveleg-fedtest.xml");
+    final Element entireMetadataDOM = XMLObjectProviderRegistrySupport.getParserPool()
       .parse(entireMetadata.getInputStream())
       .getDocumentElement();
     entireMetadataProvider = new StaticMetadataProvider(entireMetadataDOM);
@@ -95,7 +95,7 @@ public class CompositeMetadataProviderTest extends OpenSAMLTestBase {
 
     // Setup the composite provider with three providers (for the three parts)
     //
-    CompositeMetadataProvider provider =
+    final CompositeMetadataProvider provider =
         new CompositeMetadataProvider("MetadataService", Arrays.asList(new FilesystemMetadataProvider(part1.getFile()),
           new FilesystemMetadataProvider(part2.getFile()), new FilesystemMetadataProvider(part3.getFile())));
 
@@ -114,23 +114,23 @@ public class CompositeMetadataProviderTest extends OpenSAMLTestBase {
       ed = provider.getEntityDescriptor(TEST_SP, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
       Assertions.assertNotNull(ed, String.format("SPSSODescriptor for '%s' was not found", TEST_SP));
 
-      List<EntityDescriptor> idps = provider.getIdentityProviders();
+      final List<EntityDescriptor> idps = provider.getIdentityProviders();
       Assertions.assertEquals(2, idps.size(), "Expected 2 IdPs");
 
-      List<EntityDescriptor> sps = provider.getServiceProviders();
+      final List<EntityDescriptor> sps = provider.getServiceProviders();
       Assertions.assertEquals(43, sps.size(), "Expected 43 SPs");
 
-      XMLObject xmlObject = provider.getMetadata();
+      final XMLObject xmlObject = provider.getMetadata();
       Assertions.assertNotNull(xmlObject, "Could not get metadata XMLObject from provider");
       Assertions.assertTrue(xmlObject instanceof EntitiesDescriptor, "Expected EntitiesDescriptor");
 
       // Make sure that no signature is there, and so on
-      EntitiesDescriptor metadata = (EntitiesDescriptor) xmlObject;
+      final EntitiesDescriptor metadata = (EntitiesDescriptor) xmlObject;
       Assertions.assertNull(metadata.getSignature(), "Expected no signature");
       Assertions.assertEquals(provider.getID(), metadata.getName());
       Assertions.assertNotNull("Expected ID to be assigned", metadata.getID());
 
-      Element xml = provider.getMetadataDOM();
+      final Element xml = provider.getMetadataDOM();
       Assertions.assertNotNull(xml, "Could not get metadata DOM from provider");
     }
     finally {
@@ -148,16 +148,16 @@ public class CompositeMetadataProviderTest extends OpenSAMLTestBase {
    */
   @Test
   public void testDOM() throws Exception {
-    CompositeMetadataProvider provider =
+    final CompositeMetadataProvider provider =
         new CompositeMetadataProvider("MetadataService", Arrays.asList(new FilesystemMetadataProvider(part1.getFile()),
           new FilesystemMetadataProvider(part2.getFile()), new FilesystemMetadataProvider(part3.getFile())));
 
     try {
       provider.initialize();
-      Element dom = provider.getMetadataDOM();
-      EntitiesDescriptor ed = EntitiesDescriptor.class.cast(XMLObjectSupport.getUnmarshaller(dom).unmarshall(dom));
-      for (EntityDescriptor e : ed.getEntityDescriptors()) {
-        EntityDescriptor e2 = provider.getEntityDescriptor(e.getEntityID());
+      final Element dom = provider.getMetadataDOM();
+      final EntitiesDescriptor ed = (EntitiesDescriptor) XMLObjectSupport.getUnmarshaller(dom).unmarshall(dom);
+      for (final EntityDescriptor e : ed.getEntityDescriptors()) {
+        final EntityDescriptor e2 = provider.getEntityDescriptor(e.getEntityID());
         Assertions.assertNotNull(e2, String.format("EntityDescriptor for '%s' was not found", e.getEntityID()));
       }
     }

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/FilesystemMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/FilesystemMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/HTTPMetadataProvider2Test.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/HTTPMetadataProvider2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,17 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.security.cert.X509Certificate;
-import java.util.List;
-
+import net.shibboleth.shared.component.ComponentInitializationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.springframework.core.io.ClassPathResource;
-
-import net.shibboleth.shared.component.ComponentInitializationException;
 import se.swedenconnect.opensaml.OpenSAMLTestBase;
 import se.swedenconnect.opensaml.TestWebServer;
 import se.swedenconnect.security.credential.factory.X509CertificateFactoryBean;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * Additional test cases for HTTPMetadataProvider.
@@ -37,7 +36,8 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
 
   @Test
   public void testHttp() throws Exception {
-    TestWebServer server = new TestWebServer(() -> new ClassPathResource("/metadata/sveleg-fedtest.xml"), null, null);
+    final TestWebServer server =
+        new TestWebServer(() -> new ClassPathResource("/metadata/sveleg-fedtest.xml"), null, null);
     server.start();
 
     HTTPMetadataProvider provider = null;
@@ -47,7 +47,7 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
       provider.setRequireValidMetadata(true);
       provider.initialize();
 
-      EntityDescriptor ed = provider.getEntityDescriptor(BaseMetadataProviderTest.TEST_IDP);
+      final EntityDescriptor ed = provider.getEntityDescriptor(BaseMetadataProviderTest.TEST_IDP);
       Assertions.assertNotNull(ed,
           String.format("EntityDescriptor for '%s' was not found", BaseMetadataProviderTest.TEST_IDP));
     }
@@ -59,10 +59,10 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
 
   @Test
   public void testSwedenConnect() throws Exception {
-    X509CertificateFactoryBean certFactory =
+    final X509CertificateFactoryBean certFactory =
         new X509CertificateFactoryBean(new ClassPathResource("sweden-connect-prod.crt"));
     certFactory.afterPropertiesSet();
-    X509Certificate signingCert = certFactory.getObject();
+    final X509Certificate signingCert = certFactory.getObject();
     HTTPMetadataProvider provider = null;
 
     try {
@@ -73,7 +73,7 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
       provider.setSignatureVerificationCertificate(signingCert);
       provider.initialize();
 
-      List<EntityDescriptor> idps = provider.getIdentityProviders();
+      final List<EntityDescriptor> idps = provider.getIdentityProviders();
       Assertions.assertTrue(idps.size() > 1);
     }
     finally {
@@ -83,10 +83,10 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
 
   @Test
   public void testSwedenConnectNotTrusted() throws Exception {
-    X509CertificateFactoryBean certFactory =
+    final X509CertificateFactoryBean certFactory =
         new X509CertificateFactoryBean(new ClassPathResource("sweden-connect-prod.crt"));
     certFactory.afterPropertiesSet();
-    X509Certificate signingCert = certFactory.getObject();
+    final X509Certificate signingCert = certFactory.getObject();
 
     Assertions.assertThrows(ComponentInitializationException.class, () -> {
       HTTPMetadataProvider provider = null;
@@ -107,10 +107,9 @@ public class HTTPMetadataProvider2Test extends OpenSAMLTestBase {
 
   @Test
   public void testSwedenConnectFailedSignatureValidation() throws Exception {
-    X509CertificateFactoryBean certFactory = new X509CertificateFactoryBean(new ClassPathResource("testca.crt"));
+    final X509CertificateFactoryBean certFactory = new X509CertificateFactoryBean(new ClassPathResource("testca.crt"));
     certFactory.afterPropertiesSet();
-    X509Certificate signingCert = certFactory.getObject();
-
+    final X509Certificate signingCert = certFactory.getObject();
 
     Assertions.assertThrows(ComponentInitializationException.class, () -> {
       HTTPMetadataProvider provider = null;

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/HTTPMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/HTTPMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.security.KeyStore;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.core.io.Resource;
-
 import se.swedenconnect.opensaml.TestWebServer;
+
+import java.security.KeyStore;
 
 /**
  * Test cases for the {@code HTTPMetadataProvider} class.
@@ -31,7 +30,7 @@ import se.swedenconnect.opensaml.TestWebServer;
 public class HTTPMetadataProviderTest extends BaseMetadataProviderTest {
 
   /** Holds the metadata that is serviced by the web server. */
-  private static MetadataResourceProvider resourceProvider = new MetadataResourceProvider();
+  private static final MetadataResourceProvider resourceProvider = new MetadataResourceProvider();
 
   /** The TLS trust. */
   private static KeyStore trustStore;
@@ -44,7 +43,7 @@ public class HTTPMetadataProviderTest extends BaseMetadataProviderTest {
       trustStore = loadKeyStore("src/test/resources/trust.jks", "secret", null);
       server = new TestWebServer(resourceProvider, "src/test/resources/localhost.jks", "secret");
     }
-    catch (Exception e) {
+    catch (final Exception e) {
     }
   }
 
@@ -90,7 +89,7 @@ public class HTTPMetadataProviderTest extends BaseMetadataProviderTest {
 
     private Resource resource;
 
-    public void setResource(Resource resource) {
+    public void setResource(final Resource resource) {
       this.resource = resource;
     }
 

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/MDQMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,12 @@
  */
 package se.swedenconnect.opensaml.saml2.metadata.provider;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyStore;
-import java.util.function.Function;
-
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,21 +32,28 @@ import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-
 import se.swedenconnect.opensaml.OpenSAMLTestBase;
 import se.swedenconnect.opensaml.TestWebServer;
 
-public class MDQMetadataProviderTest extends OpenSAMLTestBase {
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.function.Function;
+
+class MDQMetadataProviderTest extends OpenSAMLTestBase {
 
   private static final File cacheDir = new File("target/cache");
 
-//  private X509Certificate cert;
+  //  private X509Certificate cert;
 
   /** The TLS trust. */
-  private static KeyStore trustStore;
+  private static final KeyStore trustStore;
 
   /** The web server that serves the metadata. */
-  private static TestWebServer server;
+  private static final TestWebServer server;
 
   static {
     try {
@@ -59,12 +62,13 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
           new MDQProvider(new ClassPathResource("/metadata/sveleg-fedtest.xml"))),
           "src/test/resources/localhost.jks", "secret");
     }
-    catch (Exception e) {
+    catch (final Exception e) {
+      throw new RuntimeException(e);
     }
   }
 
   @BeforeAll
-  static public void startServer() throws Exception {
+  static void startServer() throws Exception {
 
     // Since our test CA cert is missing BasicConstraints extension ...
     System.setProperty("jdk.security.allowNonCaAnchor", "true");
@@ -78,30 +82,29 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
    * @throws Exception for errors
    */
   @AfterAll
-  static public void stopServer() throws Exception {
+  static void stopServer() throws Exception {
     server.stop();
 
     System.clearProperty("jdk.security.allowNonCaAnchor");
   }
 
   @BeforeEach
-  public void init() throws Exception {
+  void init() {
     try {
       FileUtils.forceDelete(cacheDir);
     }
-    catch (Exception e) {
+    catch (final Exception ignored) {
     }
-//    this.cert = decodeCertificate(new ClassPathResource("nordunet.crt").getInputStream());
   }
 
   @Test
-  public void testGet() throws Exception {
+  void testGet() throws Exception {
 
     final MDQMetadataProvider provider = new MDQMetadataProvider(server.getUrl(),
         HTTPMetadataProvider.createDefaultHttpClient(trustStore, null),
         cacheDir.getAbsolutePath());
 
-//    provider.setSignatureVerificationCertificate(this.cert);
+    //    provider.setSignatureVerificationCertificate(this.cert);
     provider.initialize();
 
     Assertions.assertTrue(provider.getIdentityProviders().isEmpty());
@@ -117,7 +120,7 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
     Assertions.assertTrue(provider.getIdentityProviders().size() == 1);
     Assertions.assertTrue(provider.getServiceProviders().size() == 1);
 
-    EntitiesDescriptor metadata = (EntitiesDescriptor) provider.getMetadata();
+    final EntitiesDescriptor metadata = (EntitiesDescriptor) provider.getMetadata();
     Assertions.assertNotNull(metadata);
     Assertions.assertEquals(2, metadata.getEntityDescriptors().size());
 
@@ -126,52 +129,56 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
     Assertions.assertNull(ed3);
   }
 
-//  @Test
-//  public void testList() throws Exception {
-//    final MDQMetadataProvider provider = new MDQMetadataProvider("https://md.nordu.net",
-//        HTTPMetadataProvider.createDefaultHttpClient(), cacheDir.getAbsolutePath());
-//    provider.setSignatureVerificationCertificate(this.cert);
-//    provider.initialize();
-//
-//    Assert.assertTrue(provider.getIdentityProviders().isEmpty());
-//    Assert.assertTrue(provider.getServiceProviders().isEmpty());
-//
-//    // Now, get some entities using MDQ ...
-//    final EntityDescriptor ed = provider.getEntityDescriptor("http://adfs.hv.se/adfs/services/trust");
-//    Assert.assertNotNull(ed);
-//
-//    final EntityDescriptor edb = provider.getEntityDescriptor("http://adfs.hv.se/adfs/services/trust2");
-//    Assert.assertNull(edb);
-//
-//
-//    // Both a SP and IdP
-//    final EntityDescriptor ed2 = provider.getEntityDescriptor("http://adfs.helb-prigogine.be/adfs/services/trust");
-//    Assert.assertNotNull(ed2);
-//
-//    Assert.assertTrue(provider.getIdentityProviders().size() == 2);
-//    Assert.assertTrue(provider.getServiceProviders().size() == 1);
-//
-//    EntitiesDescriptor metadata = (EntitiesDescriptor) provider.getMetadata();
-//    Assert.assertNotNull(metadata);
-//    Assert.assertEquals(2, metadata.getEntityDescriptors().size());
-//  }
-//
+  //  @Test
+  //  public void testList() throws Exception {
+  //    final MDQMetadataProvider provider = new MDQMetadataProvider("https://md.nordu.net",
+  //        HTTPMetadataProvider.createDefaultHttpClient(), cacheDir.getAbsolutePath());
+  //    provider.setSignatureVerificationCertificate(this.cert);
+  //    provider.initialize();
+  //
+  //    Assert.assertTrue(provider.getIdentityProviders().isEmpty());
+  //    Assert.assertTrue(provider.getServiceProviders().isEmpty());
+  //
+  //    // Now, get some entities using MDQ ...
+  //    final EntityDescriptor ed = provider.getEntityDescriptor("http://adfs.hv.se/adfs/services/trust");
+  //    Assert.assertNotNull(ed);
+  //
+  //    final EntityDescriptor edb = provider.getEntityDescriptor("http://adfs.hv.se/adfs/services/trust2");
+  //    Assert.assertNull(edb);
+  //
+  //
+  //    // Both a SP and IdP
+  //    final EntityDescriptor ed2 = provider.getEntityDescriptor("http://adfs.helb-prigogine.be/adfs/services/trust");
+  //    Assert.assertNotNull(ed2);
+  //
+  //    Assert.assertTrue(provider.getIdentityProviders().size() == 2);
+  //    Assert.assertTrue(provider.getServiceProviders().size() == 1);
+  //
+  //    EntitiesDescriptor metadata = (EntitiesDescriptor) provider.getMetadata();
+  //    Assert.assertNotNull(metadata);
+  //    Assert.assertEquals(2, metadata.getEntityDescriptors().size());
+  //  }
+  //
 
   private static class MDQProvider implements Function<String, EntityDescriptor> {
 
-    private final EntitiesDescriptor metadata;
+    private final Resource metadataResource;
+    private EntitiesDescriptor metadata;
 
     public MDQProvider(final Resource metadataResource) {
-      try {
-        this.metadata = OpenSAMLTestBase.unmarshall(metadataResource.getInputStream(), EntitiesDescriptor.class);
-      }
-      catch (Exception e) {
-        throw new SecurityException(e);
-      }
+      this.metadataResource = metadataResource;
     }
 
     @Override
     public EntityDescriptor apply(final String id) {
+      if (this.metadata == null) {
+        try {
+          this.metadata = OpenSAMLTestBase.unmarshall(this.metadataResource.getInputStream(), EntitiesDescriptor.class);
+        }
+        catch (final Exception e) {
+          throw new SecurityException(e);
+        }
+      }
       for (final EntityDescriptor ed : this.metadata.getEntityDescriptors()) {
         if (ed.getEntityID().equals(id)) {
           return ed;
@@ -182,7 +189,7 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
 
   }
 
-  public static class MDQHandler extends AbstractHandler {
+  public static class MDQHandler extends Handler.Abstract {
 
     private final Function<String, EntityDescriptor> resourceProvider;
 
@@ -191,31 +198,30 @@ public class MDQMetadataProviderTest extends OpenSAMLTestBase {
     }
 
     @Override
-    public void handle(final String target, final Request baseRequest,
-        final jakarta.servlet.http.HttpServletRequest request,
-        final jakarta.servlet.http.HttpServletResponse response) throws IOException, jakarta.servlet.ServletException {
-
-      final int pos = request.getRequestURI().indexOf("/entities/");
+    public boolean handle(final Request request, final Response response, final Callback callback) {
+      final int pos = request.getHttpURI().asString().indexOf("/entities/");
       if (pos == -1) {
-        response.sendError(404, "Not found");
+        Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
       }
       else {
-        final String id = request.getRequestURI().substring(pos + "/entities/".length());
+        final String id = request.getHttpURI().asString().substring(pos + "/entities/".length());
         final String entityId = URLDecoder.decode(id, StandardCharsets.UTF_8);
         final EntityDescriptor ed = this.resourceProvider.apply(entityId);
         if (ed == null) {
-          response.sendError(404, "Not found");
+          Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
         }
         else {
           try {
-            XMLObjectSupport.marshallToOutputStream(ed, response.getOutputStream());
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            XMLObjectSupport.marshallToOutputStream(ed, baos);
+            response.write(true, ByteBuffer.wrap(baos.toByteArray()), callback);
           }
-          catch (final MarshallingException | IOException e) {
-            response.sendError(500, e.getMessage());
+          catch (final MarshallingException e) {
+            Response.writeError(request, response, callback, HttpStatus.INTERNAL_SERVER_ERROR_500);
           }
         }
       }
-      baseRequest.setHandled(true);
+      return true;
     }
   }
 

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/ProxyMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/ProxyMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ public class ProxyMetadataProviderTest extends BaseMetadataProviderTest {
 
   /** {@inheritDoc} */
   @Override
-  protected AbstractMetadataProvider createMetadataProvider(Resource resource) throws Exception {
-    FilesystemMetadataResolver resolver = new FilesystemMetadataResolver(resource.getFile());
+  protected AbstractMetadataProvider createMetadataProvider(final Resource resource) throws Exception {
+    final FilesystemMetadataResolver resolver = new FilesystemMetadataResolver(resource.getFile());
     resolver.setId(resource.getFilename());
     resolver.setParserPool(XMLObjectProviderRegistrySupport.getParserPool());
     return new ProxyMetadataProvider(resolver);

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/StaticMetadataProviderTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/provider/StaticMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/se/swedenconnect/opensaml/saml2/metadata/scope/ScopeUtilsTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/saml2/metadata/scope/ScopeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Sweden Connect
+ * Copyright 2016-2024 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/adfs.xml
+++ b/src/test/resources/adfs.xml
@@ -1,0 +1,514 @@
+<EntityDescriptor ID="_46a4ff39-ad96-499d-91d9-040588865218" entityID="http://adfs.server.url/adfs/services/trust"
+                  xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_46a4ff39-ad96-499d-91d9-040588865218">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>tjL/uSGbAj7aGTU/RrT2ukV7FXOnF/nmKhRD3WtN/Lo=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+      X+XDwL8chvi4SzQnrQTlyovg8wgBM1Z0ac1tozXY78E9jRkCI8Ce6fuACSK4i1Ak51NeCXev2v7c/yzFnbTaC7Y3eGYcEt2e75BUbXmEJFMiHy0MSBEKMot06LFe5zLy9NPCbc9aOVwKZT6Le8dLndG6WTHgExYdf/ujaqLFHukQ4kC5EfU+hI2SLocJGFrbFGag7Gf9asicg03sZjwB9FU4e9B/U8oyA58RKuG1U/+9BpQ5P0KJiHp2lQHTQX6M1P2CnsSXRKA6zSnPXMiD7G2qpBXl1mCkkaYIln8WRuZHd3nvrtgILAwAMlBb0XUkILUXin3rvPcoW9mPnk1vPw==
+    </ds:SignatureValue>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <X509Data>
+        <X509Certificate>
+          MIIC3DCCAcSgAwIBAgIQUpAeTBr76KxOOZBzPIhjujANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9BREZTIFNpZ25pbmcgLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzIwMFoXDTE1MDEzMDIzMzIwMFowKjEoMCYGA1UEAxMfQURGUyBTaWduaW5nIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKrpuk2psb1teCft5zrrBGzWPtiIA3Ts5opVz/bIBIVaSDnysrUi3JPUuDyx/vVf9F7D7yrPO2IfBI/bSs96fKmXFE5Rg1zsHqBJ58mOuKxwuhL2OffqPZQOyxAthJihayISSqR6mP4Z9J4O8cj6N+pWC3j1wx0Fbu1Nfeo15DHB7U+9N63Ycn7KizSdE2XiRn1veBIOG06RdznoQgK4uTpNJ6hyc+cJjsLid/tWGr4VjXa9qUK/zsVj63TalEKgVf2m8kVaD+8qBecSP9v3wIqW5my+MvCOE3EphfDcWZEPydrEZ2d3aOVMvjjGqDZtdJUBIm0Rmz4dQH8x9aB+PPkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAXvZ4ZfFlUGU/y4mB2VYEpxdFBPW8JUT5jeCXRVvGGCyTacDUNJ3w3h0TZ0fTc5jJOZCtFhNOKJQtcCUVxhJbwEBQ4HxuZBUFox0ERohYUcitEntdCU1BYvuHOgAyjpLT4nuCQ5ChomZjs5txPbFZhFKI14G/kwq4A5LRbMT0YCEBBtaqlz+C4ad7WKCq5poS6z825DrsbOBLFj8+FLQtqwiiGhHqxNFtAM1mBq/ES8GNxLANlZZ/Xw9DTnNzaM60hqYIxZmKMdGTCMs4Yu32yyCvQ7QkuKx4pL5N6LA8huxSH+EKuSKfpXOHLbE75oPMKKH+qIehWmVqyCXr2A9Ag==
+        </X509Certificate>
+      </X509Data>
+    </KeyInfo>
+  </ds:Signature>
+  <RoleDescriptor xsi:type="fed:ApplicationServiceType"
+                  protocolSupportEnumeration="http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706"
+                  ServiceDisplayName="adfs.server.url" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC4jCCAcqgAwIBAgIQXYcAQ3jZkL9Jk9d7fx+xBjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJBREZTIEVuY3J5cHRpb24gLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzE1OVoXDTE1MDEzMDIzMzE1OVowLTErMCkGA1UEAxMiQURGUyBFbmNyeXB0aW9uIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK+mqNP12dt1or2EpIpjHDwoC9Erkso3vDAwJ5vpHI7wRaTTnieiI6rtujQDDINNky98TdM7oD4JO3peaZHFuHeIsol8Gpqw9PnA7RA9mpeJ1irCp8DtSQdTcfKBLQ+YbMWSvFF4Z6xaP2BMggkB15H/+FD31BUSyBD3bLbeOlS/1loqtfyHJCYkGXc8wKLNbLItT1wku63X4YjpOOOEUh+jGoVCXYwkOhScmji/7MhdV9woqyxi5F/rmCrOIJHgqNBa4cwb/1+GSrYHNUPBLanXB+zS6hmAu3ceG9IaWDcxXqBISo0mrI80SuobLlEbk9N2JO2WDOLssMkj0/wH27MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAG04bVFpr0QNDVIFyHcuCbVFMj1ZryYT9U12mwSgkzYjaIeXIFC0UzoGK1YcsNDuFil1LUtgjak1nKNcc50LOtTKDrimRgD6OcUScMLxyogte46E1clvRYvGLiawtvFx9fM9nGyRmybKHxbmLmCXYBEgietahoGrw5ohWQov1hjIRJ4evPvUx9fqi7V13rEvL0s+J2JhbmZIkecWagn+Dno0bvWOkVmPt2A+JB5Yqu5K6wZlBMNYvKyyaKu8TwuVrWZYm+3DJazg3yycLkJDkxpEGnj+exZ8j7e0Jhcfhk1UeqJ/e/8fwcZ3IostF93+Nc2mMJHmFKfLnFDJDYtZQbw==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <fed:ClaimTypesRequested>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Given Name</auth:DisplayName>
+        <auth:Description>The given name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Name</auth:DisplayName>
+        <auth:Description>The unique name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>UPN</auth:DisplayName>
+        <auth:Description>The user principal name (UPN) of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/CommonName" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Common Name</auth:DisplayName>
+        <auth:Description>The common name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/EmailAddress" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>AD FS 1.x E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user when interoperating with AD FS 1.1 or ADFS 1.0
+        </auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/Group" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Group</auth:DisplayName>
+        <auth:Description>A group that the user is a member of</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/UPN" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>AD FS 1.x UPN</auth:DisplayName>
+        <auth:Description>The UPN of the user when interoperating with AD FS 1.1 or ADFS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Role</auth:DisplayName>
+        <auth:Description>A role that the user has</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Surname</auth:DisplayName>
+        <auth:Description>The surname of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>PPID</auth:DisplayName>
+        <auth:Description>The private identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Name ID</auth:DisplayName>
+        <auth:Description>The SAML name identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Authentication time stamp</auth:DisplayName>
+        <auth:Description>Used to display the time and date that the user was authenticated</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Authentication method</auth:DisplayName>
+        <auth:Description>The method used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only group SID</auth:DisplayName>
+        <auth:Description>The deny-only group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only primary SID</auth:DisplayName>
+        <auth:Description>The deny-only primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only primary group SID</auth:DisplayName>
+        <auth:Description>The deny-only primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Group SID</auth:DisplayName>
+        <auth:Description>The group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Primary group SID</auth:DisplayName>
+        <auth:Description>The primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Primary SID</auth:DisplayName>
+        <auth:Description>The primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Windows account name</auth:DisplayName>
+        <auth:Description>The domain account name of the user in the form of &lt;domain&gt;\&lt;user&gt;
+        </auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/EmployeeID" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>EmployeeID</auth:DisplayName>
+        <auth:Description>EmployeeID for User</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/Designation" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Designation</auth:DisplayName>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/Department" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Department</auth:DisplayName>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/username" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>username</auth:DisplayName>
+      </auth:ClaimType>
+    </fed:ClaimTypesRequested>
+    <fed:TargetScopes>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/ls/</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>http://adfs.server.url/adfs/services/trust</Address>
+      </EndpointReference>
+    </fed:TargetScopes>
+    <fed:ApplicationServiceEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+    </fed:ApplicationServiceEndpoint>
+    <fed:PassiveRequestorEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/ls/</Address>
+      </EndpointReference>
+    </fed:PassiveRequestorEndpoint>
+  </RoleDescriptor>
+  <RoleDescriptor xsi:type="fed:SecurityTokenServiceType"
+                  protocolSupportEnumeration="http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706"
+                  ServiceDisplayName="adfs.server.url" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC3DCCAcSgAwIBAgIQUpAeTBr76KxOOZBzPIhjujANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9BREZTIFNpZ25pbmcgLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzIwMFoXDTE1MDEzMDIzMzIwMFowKjEoMCYGA1UEAxMfQURGUyBTaWduaW5nIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKrpuk2psb1teCft5zrrBGzWPtiIA3Ts5opVz/bIBIVaSDnysrUi3JPUuDyx/vVf9F7D7yrPO2IfBI/bSs96fKmXFE5Rg1zsHqBJ58mOuKxwuhL2OffqPZQOyxAthJihayISSqR6mP4Z9J4O8cj6N+pWC3j1wx0Fbu1Nfeo15DHB7U+9N63Ycn7KizSdE2XiRn1veBIOG06RdznoQgK4uTpNJ6hyc+cJjsLid/tWGr4VjXa9qUK/zsVj63TalEKgVf2m8kVaD+8qBecSP9v3wIqW5my+MvCOE3EphfDcWZEPydrEZ2d3aOVMvjjGqDZtdJUBIm0Rmz4dQH8x9aB+PPkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAXvZ4ZfFlUGU/y4mB2VYEpxdFBPW8JUT5jeCXRVvGGCyTacDUNJ3w3h0TZ0fTc5jJOZCtFhNOKJQtcCUVxhJbwEBQ4HxuZBUFox0ERohYUcitEntdCU1BYvuHOgAyjpLT4nuCQ5ChomZjs5txPbFZhFKI14G/kwq4A5LRbMT0YCEBBtaqlz+C4ad7WKCq5poS6z825DrsbOBLFj8+FLQtqwiiGhHqxNFtAM1mBq/ES8GNxLANlZZ/Xw9DTnNzaM60hqYIxZmKMdGTCMs4Yu32yyCvQ7QkuKx4pL5N6LA8huxSH+EKuSKfpXOHLbE75oPMKKH+qIehWmVqyCXr2A9Ag==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <fed:TokenTypesOffered>
+      <fed:TokenType Uri="urn:oasis:names:tc:SAML:2.0:assertion"/>
+      <fed:TokenType Uri="urn:oasis:names:tc:SAML:1.0:assertion"/>
+    </fed:TokenTypesOffered>
+    <fed:ClaimTypesOffered>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Given Name</auth:DisplayName>
+        <auth:Description>The given name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Name</auth:DisplayName>
+        <auth:Description>The unique name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>UPN</auth:DisplayName>
+        <auth:Description>The user principal name (UPN) of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/CommonName" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Common Name</auth:DisplayName>
+        <auth:Description>The common name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/EmailAddress" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>AD FS 1.x E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user when interoperating with AD FS 1.1 or ADFS 1.0
+        </auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/Group" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Group</auth:DisplayName>
+        <auth:Description>A group that the user is a member of</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/claims/UPN" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>AD FS 1.x UPN</auth:DisplayName>
+        <auth:Description>The UPN of the user when interoperating with AD FS 1.1 or ADFS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Role</auth:DisplayName>
+        <auth:Description>A role that the user has</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Surname</auth:DisplayName>
+        <auth:Description>The surname of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>PPID</auth:DisplayName>
+        <auth:Description>The private identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Name ID</auth:DisplayName>
+        <auth:Description>The SAML name identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Authentication time stamp</auth:DisplayName>
+        <auth:Description>Used to display the time and date that the user was authenticated</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Authentication method</auth:DisplayName>
+        <auth:Description>The method used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only group SID</auth:DisplayName>
+        <auth:Description>The deny-only group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only primary SID</auth:DisplayName>
+        <auth:Description>The deny-only primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid"
+                      Optional="true" xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Deny only primary group SID</auth:DisplayName>
+        <auth:Description>The deny-only primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Group SID</auth:DisplayName>
+        <auth:Description>The group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Primary group SID</auth:DisplayName>
+        <auth:Description>The primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Primary SID</auth:DisplayName>
+        <auth:Description>The primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Windows account name</auth:DisplayName>
+        <auth:Description>The domain account name of the user in the form of &lt;domain&gt;\&lt;user&gt;
+        </auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/EmployeeID" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>EmployeeID</auth:DisplayName>
+        <auth:Description>EmployeeID for User</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="https://adfs.server.url/claims/myorganizationPeopleSoftEmployeeID" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>myorganizationPeopleSoftEmployeeID</auth:DisplayName>
+        <auth:Description>myorganization PeopleSOft Employee ID</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/Department" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>Department</auth:DisplayName>
+      </auth:ClaimType>
+      <auth:ClaimType Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/username" Optional="true"
+                      xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706">
+        <auth:DisplayName>username</auth:DisplayName>
+      </auth:ClaimType>
+    </fed:ClaimTypesOffered>
+    <fed:SecurityTokenServiceEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/services/trust/2005/certificatemixed</Address>
+        <Metadata>
+          <Metadata xmlns="http://schemas.xmlsoap.org/ws/2004/09/mex"
+                    xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex">
+            <wsx:MetadataSection Dialect="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns="">
+              <wsx:MetadataReference>
+                <Address xmlns="http://www.w3.org/2005/08/addressing">https://adfs.server.url/adfs/services/trust/mex
+                </Address>
+              </wsx:MetadataReference>
+            </wsx:MetadataSection>
+          </Metadata>
+        </Metadata>
+      </EndpointReference>
+    </fed:SecurityTokenServiceEndpoint>
+    <fed:PassiveRequestorEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://adfs.server.url/adfs/ls/</Address>
+      </EndpointReference>
+    </fed:PassiveRequestorEndpoint>
+  </RoleDescriptor>
+  <SPSSODescriptor WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC4jCCAcqgAwIBAgIQXYcAQ3jZkL9Jk9d7fx+xBjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJBREZTIEVuY3J5cHRpb24gLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzE1OVoXDTE1MDEzMDIzMzE1OVowLTErMCkGA1UEAxMiQURGUyBFbmNyeXB0aW9uIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK+mqNP12dt1or2EpIpjHDwoC9Erkso3vDAwJ5vpHI7wRaTTnieiI6rtujQDDINNky98TdM7oD4JO3peaZHFuHeIsol8Gpqw9PnA7RA9mpeJ1irCp8DtSQdTcfKBLQ+YbMWSvFF4Z6xaP2BMggkB15H/+FD31BUSyBD3bLbeOlS/1loqtfyHJCYkGXc8wKLNbLItT1wku63X4YjpOOOEUh+jGoVCXYwkOhScmji/7MhdV9woqyxi5F/rmCrOIJHgqNBa4cwb/1+GSrYHNUPBLanXB+zS6hmAu3ceG9IaWDcxXqBISo0mrI80SuobLlEbk9N2JO2WDOLssMkj0/wH27MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAG04bVFpr0QNDVIFyHcuCbVFMj1ZryYT9U12mwSgkzYjaIeXIFC0UzoGK1YcsNDuFil1LUtgjak1nKNcc50LOtTKDrimRgD6OcUScMLxyogte46E1clvRYvGLiawtvFx9fM9nGyRmybKHxbmLmCXYBEgietahoGrw5ohWQov1hjIRJ4evPvUx9fqi7V13rEvL0s+J2JhbmZIkecWagn+Dno0bvWOkVmPt2A+JB5Yqu5K6wZlBMNYvKyyaKu8TwuVrWZYm+3DJazg3yycLkJDkxpEGnj+exZ8j7e0Jhcfhk1UeqJ/e/8fwcZ3IostF93+Nc2mMJHmFKfLnFDJDYtZQbw==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC3DCCAcSgAwIBAgIQUpAeTBr76KxOOZBzPIhjujANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9BREZTIFNpZ25pbmcgLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzIwMFoXDTE1MDEzMDIzMzIwMFowKjEoMCYGA1UEAxMfQURGUyBTaWduaW5nIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKrpuk2psb1teCft5zrrBGzWPtiIA3Ts5opVz/bIBIVaSDnysrUi3JPUuDyx/vVf9F7D7yrPO2IfBI/bSs96fKmXFE5Rg1zsHqBJ58mOuKxwuhL2OffqPZQOyxAthJihayISSqR6mP4Z9J4O8cj6N+pWC3j1wx0Fbu1Nfeo15DHB7U+9N63Ycn7KizSdE2XiRn1veBIOG06RdznoQgK4uTpNJ6hyc+cJjsLid/tWGr4VjXa9qUK/zsVj63TalEKgVf2m8kVaD+8qBecSP9v3wIqW5my+MvCOE3EphfDcWZEPydrEZ2d3aOVMvjjGqDZtdJUBIm0Rmz4dQH8x9aB+PPkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAXvZ4ZfFlUGU/y4mB2VYEpxdFBPW8JUT5jeCXRVvGGCyTacDUNJ3w3h0TZ0fTc5jJOZCtFhNOKJQtcCUVxhJbwEBQ4HxuZBUFox0ERohYUcitEntdCU1BYvuHOgAyjpLT4nuCQ5ChomZjs5txPbFZhFKI14G/kwq4A5LRbMT0YCEBBtaqlz+C4ad7WKCq5poS6z825DrsbOBLFj8+FLQtqwiiGhHqxNFtAM1mBq/ES8GNxLANlZZ/Xw9DTnNzaM60hqYIxZmKMdGTCMs4Yu32yyCvQ7QkuKx4pL5N6LA8huxSH+EKuSKfpXOHLbE75oPMKKH+qIehWmVqyCXr2A9Ag==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                              Location="https://adfs.server.url/adfs/ls/" index="0" isDefault="true"/>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+                              Location="https://adfs.server.url/adfs/ls/" index="1"/>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                              Location="https://adfs.server.url/adfs/ls/" index="2"/>
+  </SPSSODescriptor>
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC4jCCAcqgAwIBAgIQXYcAQ3jZkL9Jk9d7fx+xBjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJBREZTIEVuY3J5cHRpb24gLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzE1OVoXDTE1MDEzMDIzMzE1OVowLTErMCkGA1UEAxMiQURGUyBFbmNyeXB0aW9uIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK+mqNP12dt1or2EpIpjHDwoC9Erkso3vDAwJ5vpHI7wRaTTnieiI6rtujQDDINNky98TdM7oD4JO3peaZHFuHeIsol8Gpqw9PnA7RA9mpeJ1irCp8DtSQdTcfKBLQ+YbMWSvFF4Z6xaP2BMggkB15H/+FD31BUSyBD3bLbeOlS/1loqtfyHJCYkGXc8wKLNbLItT1wku63X4YjpOOOEUh+jGoVCXYwkOhScmji/7MhdV9woqyxi5F/rmCrOIJHgqNBa4cwb/1+GSrYHNUPBLanXB+zS6hmAu3ceG9IaWDcxXqBISo0mrI80SuobLlEbk9N2JO2WDOLssMkj0/wH27MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAG04bVFpr0QNDVIFyHcuCbVFMj1ZryYT9U12mwSgkzYjaIeXIFC0UzoGK1YcsNDuFil1LUtgjak1nKNcc50LOtTKDrimRgD6OcUScMLxyogte46E1clvRYvGLiawtvFx9fM9nGyRmybKHxbmLmCXYBEgietahoGrw5ohWQov1hjIRJ4evPvUx9fqi7V13rEvL0s+J2JhbmZIkecWagn+Dno0bvWOkVmPt2A+JB5Yqu5K6wZlBMNYvKyyaKu8TwuVrWZYm+3DJazg3yycLkJDkxpEGnj+exZ8j7e0Jhcfhk1UeqJ/e/8fwcZ3IostF93+Nc2mMJHmFKfLnFDJDYtZQbw==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+            MIIC3DCCAcSgAwIBAgIQUpAeTBr76KxOOZBzPIhjujANBgkqhkiG9w0BAQsFADAqMSgwJgYDVQQDEx9BREZTIFNpZ25pbmcgLSBzdHMudW5pbGV2ZXIuY29tMB4XDTE0MDEzMDIzMzIwMFoXDTE1MDEzMDIzMzIwMFowKjEoMCYGA1UEAxMfQURGUyBTaWduaW5nIC0gc3RzLnVuaWxldmVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKrpuk2psb1teCft5zrrBGzWPtiIA3Ts5opVz/bIBIVaSDnysrUi3JPUuDyx/vVf9F7D7yrPO2IfBI/bSs96fKmXFE5Rg1zsHqBJ58mOuKxwuhL2OffqPZQOyxAthJihayISSqR6mP4Z9J4O8cj6N+pWC3j1wx0Fbu1Nfeo15DHB7U+9N63Ycn7KizSdE2XiRn1veBIOG06RdznoQgK4uTpNJ6hyc+cJjsLid/tWGr4VjXa9qUK/zsVj63TalEKgVf2m8kVaD+8qBecSP9v3wIqW5my+MvCOE3EphfDcWZEPydrEZ2d3aOVMvjjGqDZtdJUBIm0Rmz4dQH8x9aB+PPkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAXvZ4ZfFlUGU/y4mB2VYEpxdFBPW8JUT5jeCXRVvGGCyTacDUNJ3w3h0TZ0fTc5jJOZCtFhNOKJQtcCUVxhJbwEBQ4HxuZBUFox0ERohYUcitEntdCU1BYvuHOgAyjpLT4nuCQ5ChomZjs5txPbFZhFKI14G/kwq4A5LRbMT0YCEBBtaqlz+C4ad7WKCq5poS6z825DrsbOBLFj8+FLQtqwiiGhHqxNFtAM1mBq/ES8GNxLANlZZ/Xw9DTnNzaM60hqYIxZmKMdGTCMs4Yu32yyCvQ7QkuKx4pL5N6LA8huxSH+EKuSKfpXOHLbE75oPMKKH+qIehWmVqyCXr2A9Ag==
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                         Location="https://adfs.server.url/adfs/ls/"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="E-Mail Address"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Given Name"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Name"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="UPN"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/CommonName"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Common Name"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/EmailAddress"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="AD FS 1.x E-Mail Address"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/Group"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Group"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/UPN" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+               FriendlyName="AD FS 1.x UPN" xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Role"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Surname"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="PPID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Name ID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authentication time stamp"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authentication method"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only group SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only primary SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only primary group SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Group SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Primary group SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Primary SID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Windows account name"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/EmployeeID"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="EmployeeID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="https://adfs.server.url/claims/myorganizationPeopleSoftEmployeeID"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+               FriendlyName="myorganizationPeopleSoftEmployeeID" xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://extranet.myorganizationservices.com/claims/Type"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Type"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://extranet.myorganizationservices.com/claims/OrganisationName"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="OrganisationName"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://extranet.myorganizationservices.com/claims/OrganisationID"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="OrganisationID"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/Designation"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Designation"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/Department"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Department"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/username"
+               NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="username"
+               xmlns="urn:oasis:names:tc:SAML:2.0:assertion"/>
+  </IDPSSODescriptor>
+  <ContactPerson contactType="support"/>
+</EntityDescriptor>

--- a/src/test/resources/federationmetadata.xml
+++ b/src/test/resources/federationmetadata.xml
@@ -1,0 +1,726 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" ID="_787bee4f-3e1a-420c-9c37-0419ae45ac2d" entityID="http://fstest.example.se/adfs/services/trust">
+  <RoleDescriptor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706" xsi:type="fed:ApplicationServiceType" protocolSupportEnumeration="http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706" ServiceDisplayName="example Test IDP">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC/DCCAeSgAwIBAgIQFoDI5DKqp6dFAB1gkNY8xzANBgkqhkiG9w0BAQsFADA6MTgwNgYDVQQDEy9BREZTIEVuY3J5cHRpb24gLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0MjFaFw0yMzA5MTAxMTQ0MjFaMDoxODA2BgNVBAMTL0FERlMgRW5jcnlwdGlvbiAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArgVunyoX9oGVu9wzNaBLpEpqnxg7Wyo2Ya+iSqw+dNlBMGGadEeFWJ7U7LZ5QcgfWpJ21fN8JaNOMf3uVw4FfWVgH9j6m5jVuRA0mmXJPpRFbSEJ7KWZBkHER6Mw3eC3nPRxITeUQrU7T5R0saFdww4Y14tokzOZhVk3x/58AQaUa4P2rdbK8f/YZwT4HZlMBNpBKgR5PoNL/F4+Ll3SmGKRmUjXV6nzHeD2nNwDNQlHd6YuMp1v6PPbvOnAVJfz/UZRuB+x/yNadoZdvWbfhd4Pcw6Eg0gLsOU6nn8sNkozjpnsivOTgjy6BrBNTIf339Zv0sko+YmYVpJOvJoGlQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA0LakNgiPd3HgPIw2IBuq41kfs0fNxgc13T2yHMOH2dnh7R2iFJgXF4d+07hERA++lWtkEx5Z1mPxcW0F/a6IdDRutVgRsYPONmQJF3yKtXWp1ILDaFeJ+39YLaaI5YK+nQ4L7rtMetSmoFNfbWsvbqC4BjvxFNHDoSs3iaCUDCfs5tDoPvs4+plOM0/WFw9Ff9m5MKX96O55Fj4MmOgImBk6cEOh/koZYxMCvkUyfKkmpBIfuQ611PVpEdphLm/61A3YQpj7zNrbcjzkSektGyuMfZK12LHn2t5zYxZU/MuBjqxfhlehKJ9rRW3ZRD/0WdLl81E0iqaOAplaeNBm9</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <fed:ClaimTypesRequested>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" Optional="true">
+        <auth:DisplayName>E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" Optional="true">
+        <auth:DisplayName>Given Name</auth:DisplayName>
+        <auth:Description>The given name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" Optional="true">
+        <auth:DisplayName>Name</auth:DisplayName>
+        <auth:Description>The unique name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" Optional="true">
+        <auth:DisplayName>UPN</auth:DisplayName>
+        <auth:Description>The user principal name (UPN) of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/CommonName" Optional="true">
+        <auth:DisplayName>Common Name</auth:DisplayName>
+        <auth:Description>The common name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/EmailAddress" Optional="true">
+        <auth:DisplayName>AD FS 1.x E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user when interoperating with AD FS 1.1 or AD FS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/Group" Optional="true">
+        <auth:DisplayName>Group</auth:DisplayName>
+        <auth:Description>A group that the user is a member of</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/UPN" Optional="true">
+        <auth:DisplayName>AD FS 1.x UPN</auth:DisplayName>
+        <auth:Description>The UPN of the user when interoperating with AD FS 1.1 or AD FS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" Optional="true">
+        <auth:DisplayName>Role</auth:DisplayName>
+        <auth:Description>A role that the user has</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" Optional="true">
+        <auth:DisplayName>Surname</auth:DisplayName>
+        <auth:Description>The surname of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier" Optional="true">
+        <auth:DisplayName>PPID</auth:DisplayName>
+        <auth:Description>The private identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" Optional="true">
+        <auth:DisplayName>Name ID</auth:DisplayName>
+        <auth:Description>The SAML name identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant" Optional="true">
+        <auth:DisplayName>Authentication time stamp</auth:DisplayName>
+        <auth:Description>Used to display the time and date that the user was authenticated</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" Optional="true">
+        <auth:DisplayName>Authentication method</auth:DisplayName>
+        <auth:Description>The method used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid" Optional="true">
+        <auth:DisplayName>Deny only group SID</auth:DisplayName>
+        <auth:Description>The deny-only group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid" Optional="true">
+        <auth:DisplayName>Deny only primary SID</auth:DisplayName>
+        <auth:Description>The deny-only primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid" Optional="true">
+        <auth:DisplayName>Deny only primary group SID</auth:DisplayName>
+        <auth:Description>The deny-only primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid" Optional="true">
+        <auth:DisplayName>Group SID</auth:DisplayName>
+        <auth:Description>The group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid" Optional="true">
+        <auth:DisplayName>Primary group SID</auth:DisplayName>
+        <auth:Description>The primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid" Optional="true">
+        <auth:DisplayName>Primary SID</auth:DisplayName>
+        <auth:Description>The primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" Optional="true">
+        <auth:DisplayName>Windows account name</auth:DisplayName>
+        <auth:Description>The domain account name of the user in the form of domain\user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser" Optional="true">
+        <auth:DisplayName>Is Registered User</auth:DisplayName>
+        <auth:Description>User is registered to use this device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier" Optional="true">
+        <auth:DisplayName>Device Identifier</auth:DisplayName>
+        <auth:Description>Identifier of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/registrationid" Optional="true">
+        <auth:DisplayName>Device Registration Identifier</auth:DisplayName>
+        <auth:Description>Identifier for Device Registration</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/displayname" Optional="true">
+        <auth:DisplayName>Device Registration DisplayName</auth:DisplayName>
+        <auth:Description>Display name of Device Registration</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/ostype" Optional="true">
+        <auth:DisplayName>Device OS type</auth:DisplayName>
+        <auth:Description>OS type of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/osversion" Optional="true">
+        <auth:DisplayName>Device OS Version</auth:DisplayName>
+        <auth:Description>OS version of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/ismanaged" Optional="true">
+        <auth:DisplayName>Is Managed Device</auth:DisplayName>
+        <auth:Description>Device is managed by a management service</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip" Optional="true">
+        <auth:DisplayName>Forwarded Client IP</auth:DisplayName>
+        <auth:Description>IP address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application" Optional="true">
+        <auth:DisplayName>Client Application</auth:DisplayName>
+        <auth:Description>Type of the Client Application</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-user-agent" Optional="true">
+        <auth:DisplayName>Client User Agent</auth:DisplayName>
+        <auth:Description>Device type the client is using to access the application</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-ip" Optional="true">
+        <auth:DisplayName>Client IP</auth:DisplayName>
+        <auth:Description>IP address of the client</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path" Optional="true">
+        <auth:DisplayName>Endpoint Path</auth:DisplayName>
+        <auth:Description>Absolute Endpoint path which can be used to determine active versus passive clients</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-proxy" Optional="true">
+        <auth:DisplayName>Proxy</auth:DisplayName>
+        <auth:Description>DNS name of the federation server proxy that passed the request</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/relyingpartytrustid" Optional="true">
+        <auth:DisplayName>Application Identifier</auth:DisplayName>
+        <auth:Description>Identifier for the Relying Party</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/applicationpolicy" Optional="true">
+        <auth:DisplayName>Application policies</auth:DisplayName>
+        <auth:Description>Application policies of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/authoritykeyidentifier" Optional="true">
+        <auth:DisplayName>Authority Key Identifier</auth:DisplayName>
+        <auth:Description>The Authority Key Identifier extension of the certificate that signed an issued certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/basicconstraints" Optional="true">
+        <auth:DisplayName>Basic Constraint</auth:DisplayName>
+        <auth:Description>One of the basic constraints of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/eku" Optional="true">
+        <auth:DisplayName>Enhanced Key Usage</auth:DisplayName>
+        <auth:Description>Describes one of the enhanced key usages of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuer" Optional="true">
+        <auth:DisplayName>Issuer</auth:DisplayName>
+        <auth:Description>The name of the certificate authority that issued the X.509 certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuername" Optional="true">
+        <auth:DisplayName>Issuer Name</auth:DisplayName>
+        <auth:Description>The distinguished name of the certificate issuer</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/keyusage" Optional="true">
+        <auth:DisplayName>Key Usage</auth:DisplayName>
+        <auth:Description>One of the key usages of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/notafter" Optional="true">
+        <auth:DisplayName>Not After</auth:DisplayName>
+        <auth:Description>Date in local time after which a certificate is no longer valid</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/notbefore" Optional="true">
+        <auth:DisplayName>Not Before</auth:DisplayName>
+        <auth:Description>The date in local time on which a certificate becomes valid</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatepolicy" Optional="true">
+        <auth:DisplayName>Certificate Policies</auth:DisplayName>
+        <auth:Description>The policies under which the certificate has been issued</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/rsa" Optional="true">
+        <auth:DisplayName>Public Key</auth:DisplayName>
+        <auth:Description>Public Key of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/rawdata" Optional="true">
+        <auth:DisplayName>Certificate Raw Data</auth:DisplayName>
+        <auth:Description>The raw data of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/san" Optional="true">
+        <auth:DisplayName>Subject Alternative Name</auth:DisplayName>
+        <auth:Description>One of the alternative names of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/serialnumber" Optional="true">
+        <auth:DisplayName>Serial Number</auth:DisplayName>
+        <auth:Description>The serial number of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/signaturealgorithm" Optional="true">
+        <auth:DisplayName>Signature Algorithm</auth:DisplayName>
+        <auth:Description>The algorithm used to create the signature of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/subject" Optional="true">
+        <auth:DisplayName>Subject</auth:DisplayName>
+        <auth:Description>The subject from the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/subjectkeyidentifier" Optional="true">
+        <auth:DisplayName>Subject Key Identifier</auth:DisplayName>
+        <auth:Description>Describes the subject key identifier of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname" Optional="true">
+        <auth:DisplayName>Subject Name</auth:DisplayName>
+        <auth:Description>The subject distinguished name from a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplateinformation" Optional="true">
+        <auth:DisplayName>V2 Template Name</auth:DisplayName>
+        <auth:Description>The name of the version 2 certificate template used when issuing or renewing a certificate. The extension is Microsoft specific.</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplatename" Optional="true">
+        <auth:DisplayName>V1 Template Name</auth:DisplayName>
+        <auth:Description>The name of the version 1 certificate template used when issuing or renewing a certificate. The extension is Microsoft specific.</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/thumbprint" Optional="true">
+        <auth:DisplayName>Thumbprint</auth:DisplayName>
+        <auth:Description>Thumbprint of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/x509version" Optional="true">
+        <auth:DisplayName>X.509 Version</auth:DisplayName>
+        <auth:Description>The X.509 format version of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork" Optional="true">
+        <auth:DisplayName>Inside Corporate Network</auth:DisplayName>
+        <auth:Description>Used to indicate if a request originated inside corporate network</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime" Optional="true">
+        <auth:DisplayName>Password Expiration Time</auth:DisplayName>
+        <auth:Description>Used to display the time when the password expires</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays" Optional="true">
+        <auth:DisplayName>Password Expiration Days</auth:DisplayName>
+        <auth:Description>Used to display the number of days to password expiry</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordchangeurl" Optional="true">
+        <auth:DisplayName>Update Password URL</auth:DisplayName>
+        <auth:Description>Used to display the web address of update password service</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/claims/authnmethodsreferences" Optional="true">
+        <auth:DisplayName>Authentication Methods References</auth:DisplayName>
+        <auth:Description>Used to indicate all authentication methods used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/client-request-id" Optional="true">
+        <auth:DisplayName>Client Request ID</auth:DisplayName>
+        <auth:Description>Identifier for a user session</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2013/11/alternateloginid" Optional="true">
+        <auth:DisplayName>Alternate Login ID</auth:DisplayName>
+        <auth:Description>Alternate login ID of the user</auth:Description>
+      </auth:ClaimType>
+    </fed:ClaimTypesRequested>
+    <fed:TargetScopes>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/ls/</Address>
+      </EndpointReference>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>http://fstest.example.se/adfs/services/trust</Address>
+      </EndpointReference>
+    </fed:TargetScopes>
+    <fed:ApplicationServiceEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</Address>
+      </EndpointReference>
+    </fed:ApplicationServiceEndpoint>
+    <fed:PassiveRequestorEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/ls/</Address>
+      </EndpointReference>
+    </fed:PassiveRequestorEndpoint>
+  </RoleDescriptor>
+  <RoleDescriptor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706" xsi:type="fed:SecurityTokenServiceType" protocolSupportEnumeration="http://docs.oasis-open.org/ws-sx/ws-trust/200512 http://schemas.xmlsoap.org/ws/2005/02/trust http://docs.oasis-open.org/wsfed/federation/200706" ServiceDisplayName="example Test IDP">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQMs5C0bFTDJdNO3MR29V0LTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0NTZaFw0yMzA5MTAxMTQ0NTZaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv432A4H+7ejoRbo28ipgOY/J9rOiopulqX8G1HiM9zWbXnbE4diVBBaut9zOhIM7pFpJZFFxMr+E3VSx+klo2NYOAhgVIbmWSQGLHryZ+vQkhbB1Bi2wKb6d+09TCda5lnf96KT6UtsQWEHR3IKKj95e7vEPDjz22imZRDi8EDsnTsKyc1Z5fAakhOXvBDODlRklOKBzkl/vDeHiwxRd6m9kOnekRmFI7PYhD+rS86iS2Zl7SnzEWCzIUvkKkvr3U+9lCoIkaXCd2cpaAT9j6QZAQ+EpoOzfzvX1mb68Xa1tFRkfjh3yzsQZrylJMn4sy+whUvwSq9cVKCQkRRk1iQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAYsSRnANO5MPHfq7YHZPrkC39heRmF664xxcKEU7unUuskmeryn8vVT53Il8WMrtjOz3/6b3Ol55WxqyGqOtz4KU3qB3p1GLW3yYgejRb/WBDobK66+jDYk1hNeNNFIrQzGEGmY2/WBloThttctEZPKCviK9CVDfHjEdf7n0kTUQNMJIp941dkW1ImBCabK4clU6sTQCV7GkqHEF/3dCaQEXEMlabne25dKbOrsD6G19TrIr7RjRJpqHbH8XNwMBweb6Oiss51/5JK0VGCY5OS3IvTH1GJb21DdGhQCOx8BdZYUZQHKnamAY/IomI1QdL53LPeExet88m1Pi4zeczT</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQHqXpgFbkQr1K1bxANAIIaTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMzAxMjQxMjA3MTRaFw0yNTAxMjMxMjA3MTRaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtsRM+rcjG3LzyKrWDgIpuENdslDeVcgpmwbCRD6T0lhncPnJqfYju1nvODZHQE9Z8Ny0kUszqQV1G81Qv053kZULG1XsPFUBvimlxbaEg383+s6HOavB22AtTIS8x4oRlLMn3g+bYVXW4m10WniRPFu4A+H8x+im8nApVuD/FcUtKAm/ez64RY0dIaz+RouZmRUxPQVTaNZNzqa3n6UR2RlCmCfaVKQKT30wq12Vnz8eYTj2vR68tcx+KfwZlWohrvQbAas0M9T7r3zhNTmfPstn7x1HLLl3MrG4qZmxQiaWHUr1999RlCeoESbfPtPIkamwe9YUfDt17KmXMkNHNQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBOm0z00G7eQnaURJU/uld8WZEP/TSFug0XkSjAjfuR1SlmvONedlDNipovWi0+3lu0u4NHN7DVy7emJw+iyp00kf1wmufVru5B7O5TvN7Ra1O3KZRgjQqrZe4ipRt8wRsZi2y/oXpEZ/EjZOyu1qA/tO/zszsrwJGQcOQWntNTowwP0CpZmnrfGys5+jmG48gJIVkamixseok7pfcawIo7JZHYWRxNCIktiEUhEcXxkWG02p4GjVqmhdR/vQGDp/Ov/MvscE658v+Wj9Iha6xOX84TYKhWYDnu5EFBvSobO4ORjfzSYfgU78yaQ8+Ii+H2+lmk0CSU3xDkp1Bdl7gb</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <fed:TokenTypesOffered>
+      <fed:TokenType Uri="urn:oasis:names:tc:SAML:2.0:assertion"/>
+      <fed:TokenType Uri="urn:oasis:names:tc:SAML:1.0:assertion"/>
+    </fed:TokenTypesOffered>
+    <fed:ClaimTypesOffered>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" Optional="true">
+        <auth:DisplayName>E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" Optional="true">
+        <auth:DisplayName>Given Name</auth:DisplayName>
+        <auth:Description>The given name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" Optional="true">
+        <auth:DisplayName>Name</auth:DisplayName>
+        <auth:Description>The unique name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" Optional="true">
+        <auth:DisplayName>UPN</auth:DisplayName>
+        <auth:Description>The user principal name (UPN) of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/CommonName" Optional="true">
+        <auth:DisplayName>Common Name</auth:DisplayName>
+        <auth:Description>The common name of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/EmailAddress" Optional="true">
+        <auth:DisplayName>AD FS 1.x E-Mail Address</auth:DisplayName>
+        <auth:Description>The e-mail address of the user when interoperating with AD FS 1.1 or AD FS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/Group" Optional="true">
+        <auth:DisplayName>Group</auth:DisplayName>
+        <auth:Description>A group that the user is a member of</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/claims/UPN" Optional="true">
+        <auth:DisplayName>AD FS 1.x UPN</auth:DisplayName>
+        <auth:Description>The UPN of the user when interoperating with AD FS 1.1 or AD FS 1.0</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" Optional="true">
+        <auth:DisplayName>Role</auth:DisplayName>
+        <auth:Description>A role that the user has</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" Optional="true">
+        <auth:DisplayName>Surname</auth:DisplayName>
+        <auth:Description>The surname of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier" Optional="true">
+        <auth:DisplayName>PPID</auth:DisplayName>
+        <auth:Description>The private identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" Optional="true">
+        <auth:DisplayName>Name ID</auth:DisplayName>
+        <auth:Description>The SAML name identifier of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant" Optional="true">
+        <auth:DisplayName>Authentication time stamp</auth:DisplayName>
+        <auth:Description>Used to display the time and date that the user was authenticated</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" Optional="true">
+        <auth:DisplayName>Authentication method</auth:DisplayName>
+        <auth:Description>The method used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid" Optional="true">
+        <auth:DisplayName>Deny only group SID</auth:DisplayName>
+        <auth:Description>The deny-only group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid" Optional="true">
+        <auth:DisplayName>Deny only primary SID</auth:DisplayName>
+        <auth:Description>The deny-only primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid" Optional="true">
+        <auth:DisplayName>Deny only primary group SID</auth:DisplayName>
+        <auth:Description>The deny-only primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid" Optional="true">
+        <auth:DisplayName>Group SID</auth:DisplayName>
+        <auth:Description>The group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid" Optional="true">
+        <auth:DisplayName>Primary group SID</auth:DisplayName>
+        <auth:Description>The primary group SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid" Optional="true">
+        <auth:DisplayName>Primary SID</auth:DisplayName>
+        <auth:Description>The primary SID of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" Optional="true">
+        <auth:DisplayName>Windows account name</auth:DisplayName>
+        <auth:Description>The domain account name of the user in the form of domain\user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser" Optional="true">
+        <auth:DisplayName>Is Registered User</auth:DisplayName>
+        <auth:Description>User is registered to use this device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier" Optional="true">
+        <auth:DisplayName>Device Identifier</auth:DisplayName>
+        <auth:Description>Identifier of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/registrationid" Optional="true">
+        <auth:DisplayName>Device Registration Identifier</auth:DisplayName>
+        <auth:Description>Identifier for Device Registration</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/displayname" Optional="true">
+        <auth:DisplayName>Device Registration DisplayName</auth:DisplayName>
+        <auth:Description>Display name of Device Registration</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/ostype" Optional="true">
+        <auth:DisplayName>Device OS type</auth:DisplayName>
+        <auth:Description>OS type of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/osversion" Optional="true">
+        <auth:DisplayName>Device OS Version</auth:DisplayName>
+        <auth:Description>OS version of the device</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/devicecontext/claims/ismanaged" Optional="true">
+        <auth:DisplayName>Is Managed Device</auth:DisplayName>
+        <auth:Description>Device is managed by a management service</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip" Optional="true">
+        <auth:DisplayName>Forwarded Client IP</auth:DisplayName>
+        <auth:Description>IP address of the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application" Optional="true">
+        <auth:DisplayName>Client Application</auth:DisplayName>
+        <auth:Description>Type of the Client Application</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-user-agent" Optional="true">
+        <auth:DisplayName>Client User Agent</auth:DisplayName>
+        <auth:Description>Device type the client is using to access the application</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-ip" Optional="true">
+        <auth:DisplayName>Client IP</auth:DisplayName>
+        <auth:Description>IP address of the client</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path" Optional="true">
+        <auth:DisplayName>Endpoint Path</auth:DisplayName>
+        <auth:Description>Absolute Endpoint path which can be used to determine active versus passive clients</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-proxy" Optional="true">
+        <auth:DisplayName>Proxy</auth:DisplayName>
+        <auth:Description>DNS name of the federation server proxy that passed the request</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/relyingpartytrustid" Optional="true">
+        <auth:DisplayName>Application Identifier</auth:DisplayName>
+        <auth:Description>Identifier for the Relying Party</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/applicationpolicy" Optional="true">
+        <auth:DisplayName>Application policies</auth:DisplayName>
+        <auth:Description>Application policies of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/authoritykeyidentifier" Optional="true">
+        <auth:DisplayName>Authority Key Identifier</auth:DisplayName>
+        <auth:Description>The Authority Key Identifier extension of the certificate that signed an issued certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/basicconstraints" Optional="true">
+        <auth:DisplayName>Basic Constraint</auth:DisplayName>
+        <auth:Description>One of the basic constraints of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/eku" Optional="true">
+        <auth:DisplayName>Enhanced Key Usage</auth:DisplayName>
+        <auth:Description>Describes one of the enhanced key usages of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuer" Optional="true">
+        <auth:DisplayName>Issuer</auth:DisplayName>
+        <auth:Description>The name of the certificate authority that issued the X.509 certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuername" Optional="true">
+        <auth:DisplayName>Issuer Name</auth:DisplayName>
+        <auth:Description>The distinguished name of the certificate issuer</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/keyusage" Optional="true">
+        <auth:DisplayName>Key Usage</auth:DisplayName>
+        <auth:Description>One of the key usages of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/notafter" Optional="true">
+        <auth:DisplayName>Not After</auth:DisplayName>
+        <auth:Description>Date in local time after which a certificate is no longer valid</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/notbefore" Optional="true">
+        <auth:DisplayName>Not Before</auth:DisplayName>
+        <auth:Description>The date in local time on which a certificate becomes valid</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatepolicy" Optional="true">
+        <auth:DisplayName>Certificate Policies</auth:DisplayName>
+        <auth:Description>The policies under which the certificate has been issued</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/rsa" Optional="true">
+        <auth:DisplayName>Public Key</auth:DisplayName>
+        <auth:Description>Public Key of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/rawdata" Optional="true">
+        <auth:DisplayName>Certificate Raw Data</auth:DisplayName>
+        <auth:Description>The raw data of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/san" Optional="true">
+        <auth:DisplayName>Subject Alternative Name</auth:DisplayName>
+        <auth:Description>One of the alternative names of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2008/06/identity/claims/serialnumber" Optional="true">
+        <auth:DisplayName>Serial Number</auth:DisplayName>
+        <auth:Description>The serial number of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/signaturealgorithm" Optional="true">
+        <auth:DisplayName>Signature Algorithm</auth:DisplayName>
+        <auth:Description>The algorithm used to create the signature of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/subject" Optional="true">
+        <auth:DisplayName>Subject</auth:DisplayName>
+        <auth:Description>The subject from the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/subjectkeyidentifier" Optional="true">
+        <auth:DisplayName>Subject Key Identifier</auth:DisplayName>
+        <auth:Description>Describes the subject key identifier of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname" Optional="true">
+        <auth:DisplayName>Subject Name</auth:DisplayName>
+        <auth:Description>The subject distinguished name from a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplateinformation" Optional="true">
+        <auth:DisplayName>V2 Template Name</auth:DisplayName>
+        <auth:Description>The name of the version 2 certificate template used when issuing or renewing a certificate. The extension is Microsoft specific.</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplatename" Optional="true">
+        <auth:DisplayName>V1 Template Name</auth:DisplayName>
+        <auth:Description>The name of the version 1 certificate template used when issuing or renewing a certificate. The extension is Microsoft specific.</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/thumbprint" Optional="true">
+        <auth:DisplayName>Thumbprint</auth:DisplayName>
+        <auth:Description>Thumbprint of the certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/12/certificatecontext/field/x509version" Optional="true">
+        <auth:DisplayName>X.509 Version</auth:DisplayName>
+        <auth:Description>The X.509 format version of a certificate</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork" Optional="true">
+        <auth:DisplayName>Inside Corporate Network</auth:DisplayName>
+        <auth:Description>Used to indicate if a request originated inside corporate network</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime" Optional="true">
+        <auth:DisplayName>Password Expiration Time</auth:DisplayName>
+        <auth:Description>Used to display the time when the password expires</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays" Optional="true">
+        <auth:DisplayName>Password Expiration Days</auth:DisplayName>
+        <auth:Description>Used to display the number of days to password expiry</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2012/01/passwordchangeurl" Optional="true">
+        <auth:DisplayName>Update Password URL</auth:DisplayName>
+        <auth:Description>Used to display the web address of update password service</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/claims/authnmethodsreferences" Optional="true">
+        <auth:DisplayName>Authentication Methods References</auth:DisplayName>
+        <auth:Description>Used to indicate all authentication methods used to authenticate the user</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/2012/01/requestcontext/claims/client-request-id" Optional="true">
+        <auth:DisplayName>Client Request ID</auth:DisplayName>
+        <auth:Description>Identifier for a user session</auth:Description>
+      </auth:ClaimType>
+      <auth:ClaimType xmlns:auth="http://docs.oasis-open.org/wsfed/authorization/200706" Uri="http://schemas.microsoft.com/ws/2013/11/alternateloginid" Optional="true">
+        <auth:DisplayName>Alternate Login ID</auth:DisplayName>
+        <auth:Description>Alternate login ID of the user</auth:Description>
+      </auth:ClaimType>
+    </fed:ClaimTypesOffered>
+    <fed:SecurityTokenServiceEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/services/trust/2005/certificatemixed</Address>
+        <Metadata>
+          <Metadata xmlns="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex">
+            <wsx:MetadataSection xmlns="" Dialect="http://schemas.xmlsoap.org/ws/2004/09/mex">
+              <wsx:MetadataReference>
+                <Address xmlns="http://www.w3.org/2005/08/addressing">https://fstest.example.se/adfs/services/trust/mex</Address>
+              </wsx:MetadataReference>
+            </wsx:MetadataSection>
+          </Metadata>
+        </Metadata>
+      </EndpointReference>
+    </fed:SecurityTokenServiceEndpoint>
+    <fed:PassiveRequestorEndpoint>
+      <EndpointReference xmlns="http://www.w3.org/2005/08/addressing">
+        <Address>https://fstest.example.se/adfs/ls/</Address>
+      </EndpointReference>
+    </fed:PassiveRequestorEndpoint>
+  </RoleDescriptor>
+  <SPSSODescriptor WantAssertionsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC/DCCAeSgAwIBAgIQFoDI5DKqp6dFAB1gkNY8xzANBgkqhkiG9w0BAQsFADA6MTgwNgYDVQQDEy9BREZTIEVuY3J5cHRpb24gLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0MjFaFw0yMzA5MTAxMTQ0MjFaMDoxODA2BgNVBAMTL0FERlMgRW5jcnlwdGlvbiAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArgVunyoX9oGVu9wzNaBLpEpqnxg7Wyo2Ya+iSqw+dNlBMGGadEeFWJ7U7LZ5QcgfWpJ21fN8JaNOMf3uVw4FfWVgH9j6m5jVuRA0mmXJPpRFbSEJ7KWZBkHER6Mw3eC3nPRxITeUQrU7T5R0saFdww4Y14tokzOZhVk3x/58AQaUa4P2rdbK8f/YZwT4HZlMBNpBKgR5PoNL/F4+Ll3SmGKRmUjXV6nzHeD2nNwDNQlHd6YuMp1v6PPbvOnAVJfz/UZRuB+x/yNadoZdvWbfhd4Pcw6Eg0gLsOU6nn8sNkozjpnsivOTgjy6BrBNTIf339Zv0sko+YmYVpJOvJoGlQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA0LakNgiPd3HgPIw2IBuq41kfs0fNxgc13T2yHMOH2dnh7R2iFJgXF4d+07hERA++lWtkEx5Z1mPxcW0F/a6IdDRutVgRsYPONmQJF3yKtXWp1ILDaFeJ+39YLaaI5YK+nQ4L7rtMetSmoFNfbWsvbqC4BjvxFNHDoSs3iaCUDCfs5tDoPvs4+plOM0/WFw9Ff9m5MKX96O55Fj4MmOgImBk6cEOh/koZYxMCvkUyfKkmpBIfuQ611PVpEdphLm/61A3YQpj7zNrbcjzkSektGyuMfZK12LHn2t5zYxZU/MuBjqxfhlehKJ9rRW3ZRD/0WdLl81E0iqaOAplaeNBm9</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQMs5C0bFTDJdNO3MR29V0LTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0NTZaFw0yMzA5MTAxMTQ0NTZaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv432A4H+7ejoRbo28ipgOY/J9rOiopulqX8G1HiM9zWbXnbE4diVBBaut9zOhIM7pFpJZFFxMr+E3VSx+klo2NYOAhgVIbmWSQGLHryZ+vQkhbB1Bi2wKb6d+09TCda5lnf96KT6UtsQWEHR3IKKj95e7vEPDjz22imZRDi8EDsnTsKyc1Z5fAakhOXvBDODlRklOKBzkl/vDeHiwxRd6m9kOnekRmFI7PYhD+rS86iS2Zl7SnzEWCzIUvkKkvr3U+9lCoIkaXCd2cpaAT9j6QZAQ+EpoOzfzvX1mb68Xa1tFRkfjh3yzsQZrylJMn4sy+whUvwSq9cVKCQkRRk1iQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAYsSRnANO5MPHfq7YHZPrkC39heRmF664xxcKEU7unUuskmeryn8vVT53Il8WMrtjOz3/6b3Ol55WxqyGqOtz4KU3qB3p1GLW3yYgejRb/WBDobK66+jDYk1hNeNNFIrQzGEGmY2/WBloThttctEZPKCviK9CVDfHjEdf7n0kTUQNMJIp941dkW1ImBCabK4clU6sTQCV7GkqHEF/3dCaQEXEMlabne25dKbOrsD6G19TrIr7RjRJpqHbH8XNwMBweb6Oiss51/5JK0VGCY5OS3IvTH1GJb21DdGhQCOx8BdZYUZQHKnamAY/IomI1QdL53LPeExet88m1Pi4zeczT</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQHqXpgFbkQr1K1bxANAIIaTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMzAxMjQxMjA3MTRaFw0yNTAxMjMxMjA3MTRaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtsRM+rcjG3LzyKrWDgIpuENdslDeVcgpmwbCRD6T0lhncPnJqfYju1nvODZHQE9Z8Ny0kUszqQV1G81Qv053kZULG1XsPFUBvimlxbaEg383+s6HOavB22AtTIS8x4oRlLMn3g+bYVXW4m10WniRPFu4A+H8x+im8nApVuD/FcUtKAm/ez64RY0dIaz+RouZmRUxPQVTaNZNzqa3n6UR2RlCmCfaVKQKT30wq12Vnz8eYTj2vR68tcx+KfwZlWohrvQbAas0M9T7r3zhNTmfPstn7x1HLLl3MrG4qZmxQiaWHUr1999RlCeoESbfPtPIkamwe9YUfDt17KmXMkNHNQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBOm0z00G7eQnaURJU/uld8WZEP/TSFug0XkSjAjfuR1SlmvONedlDNipovWi0+3lu0u4NHN7DVy7emJw+iyp00kf1wmufVru5B7O5TvN7Ra1O3KZRgjQqrZe4ipRt8wRsZi2y/oXpEZ/EjZOyu1qA/tO/zszsrwJGQcOQWntNTowwP0CpZmnrfGys5+jmG48gJIVkamixseok7pfcawIo7JZHYWRxNCIktiEUhEcXxkWG02p4GjVqmhdR/vQGDp/Ov/MvscE658v+Wj9Iha6xOX84TYKhWYDnu5EFBvSobO4ORjfzSYfgU78yaQ8+Ii+H2+lmk0CSU3xDkp1Bdl7gb</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://fstest.example.se/adfs/ls/"/>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fstest.example.se/adfs/ls/"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fstest.example.se/adfs/ls/" index="0" isDefault="true"/>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://fstest.example.se/adfs/ls/" index="1"/>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://fstest.example.se/adfs/ls/" index="2"/>
+  </SPSSODescriptor>
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC/DCCAeSgAwIBAgIQFoDI5DKqp6dFAB1gkNY8xzANBgkqhkiG9w0BAQsFADA6MTgwNgYDVQQDEy9BREZTIEVuY3J5cHRpb24gLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0MjFaFw0yMzA5MTAxMTQ0MjFaMDoxODA2BgNVBAMTL0FERlMgRW5jcnlwdGlvbiAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArgVunyoX9oGVu9wzNaBLpEpqnxg7Wyo2Ya+iSqw+dNlBMGGadEeFWJ7U7LZ5QcgfWpJ21fN8JaNOMf3uVw4FfWVgH9j6m5jVuRA0mmXJPpRFbSEJ7KWZBkHER6Mw3eC3nPRxITeUQrU7T5R0saFdww4Y14tokzOZhVk3x/58AQaUa4P2rdbK8f/YZwT4HZlMBNpBKgR5PoNL/F4+Ll3SmGKRmUjXV6nzHeD2nNwDNQlHd6YuMp1v6PPbvOnAVJfz/UZRuB+x/yNadoZdvWbfhd4Pcw6Eg0gLsOU6nn8sNkozjpnsivOTgjy6BrBNTIf339Zv0sko+YmYVpJOvJoGlQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA0LakNgiPd3HgPIw2IBuq41kfs0fNxgc13T2yHMOH2dnh7R2iFJgXF4d+07hERA++lWtkEx5Z1mPxcW0F/a6IdDRutVgRsYPONmQJF3yKtXWp1ILDaFeJ+39YLaaI5YK+nQ4L7rtMetSmoFNfbWsvbqC4BjvxFNHDoSs3iaCUDCfs5tDoPvs4+plOM0/WFw9Ff9m5MKX96O55Fj4MmOgImBk6cEOh/koZYxMCvkUyfKkmpBIfuQ611PVpEdphLm/61A3YQpj7zNrbcjzkSektGyuMfZK12LHn2t5zYxZU/MuBjqxfhlehKJ9rRW3ZRD/0WdLl81E0iqaOAplaeNBm9</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQMs5C0bFTDJdNO3MR29V0LTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMTA5MTAxMTQ0NTZaFw0yMzA5MTAxMTQ0NTZaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv432A4H+7ejoRbo28ipgOY/J9rOiopulqX8G1HiM9zWbXnbE4diVBBaut9zOhIM7pFpJZFFxMr+E3VSx+klo2NYOAhgVIbmWSQGLHryZ+vQkhbB1Bi2wKb6d+09TCda5lnf96KT6UtsQWEHR3IKKj95e7vEPDjz22imZRDi8EDsnTsKyc1Z5fAakhOXvBDODlRklOKBzkl/vDeHiwxRd6m9kOnekRmFI7PYhD+rS86iS2Zl7SnzEWCzIUvkKkvr3U+9lCoIkaXCd2cpaAT9j6QZAQ+EpoOzfzvX1mb68Xa1tFRkfjh3yzsQZrylJMn4sy+whUvwSq9cVKCQkRRk1iQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAYsSRnANO5MPHfq7YHZPrkC39heRmF664xxcKEU7unUuskmeryn8vVT53Il8WMrtjOz3/6b3Ol55WxqyGqOtz4KU3qB3p1GLW3yYgejRb/WBDobK66+jDYk1hNeNNFIrQzGEGmY2/WBloThttctEZPKCviK9CVDfHjEdf7n0kTUQNMJIp941dkW1ImBCabK4clU6sTQCV7GkqHEF/3dCaQEXEMlabne25dKbOrsD6G19TrIr7RjRJpqHbH8XNwMBweb6Oiss51/5JK0VGCY5OS3IvTH1GJb21DdGhQCOx8BdZYUZQHKnamAY/IomI1QdL53LPeExet88m1Pi4zeczT</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIIC9jCCAd6gAwIBAgIQHqXpgFbkQr1K1bxANAIIaTANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBmc3Rlc3QucGVuc2lvbnNteW5kaWdoZXRlbi5zZTAeFw0yMzAxMjQxMjA3MTRaFw0yNTAxMjMxMjA3MTRaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGZzdGVzdC5wZW5zaW9uc215bmRpZ2hldGVuLnNlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtsRM+rcjG3LzyKrWDgIpuENdslDeVcgpmwbCRD6T0lhncPnJqfYju1nvODZHQE9Z8Ny0kUszqQV1G81Qv053kZULG1XsPFUBvimlxbaEg383+s6HOavB22AtTIS8x4oRlLMn3g+bYVXW4m10WniRPFu4A+H8x+im8nApVuD/FcUtKAm/ez64RY0dIaz+RouZmRUxPQVTaNZNzqa3n6UR2RlCmCfaVKQKT30wq12Vnz8eYTj2vR68tcx+KfwZlWohrvQbAas0M9T7r3zhNTmfPstn7x1HLLl3MrG4qZmxQiaWHUr1999RlCeoESbfPtPIkamwe9YUfDt17KmXMkNHNQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBOm0z00G7eQnaURJU/uld8WZEP/TSFug0XkSjAjfuR1SlmvONedlDNipovWi0+3lu0u4NHN7DVy7emJw+iyp00kf1wmufVru5B7O5TvN7Ra1O3KZRgjQqrZe4ipRt8wRsZi2y/oXpEZ/EjZOyu1qA/tO/zszsrwJGQcOQWntNTowwP0CpZmnrfGys5+jmG48gJIVkamixseok7pfcawIo7JZHYWRxNCIktiEUhEcXxkWG02p4GjVqmhdR/vQGDp/Ov/MvscE658v+Wj9Iha6xOX84TYKhWYDnu5EFBvSobO4ORjfzSYfgU78yaQ8+Ii+H2+lmk0CSU3xDkp1Bdl7gb</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://fstest.example.se/adfs/ls/"/>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fstest.example.se/adfs/ls/"/>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://fstest.example.se/adfs/ls/"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://fstest.example.se/adfs/ls/"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="E-Mail Address"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Given Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="UPN"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/claims/CommonName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Common Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/claims/EmailAddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="AD FS 1.x E-Mail Address"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/claims/Group" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Group"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/claims/UPN" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="AD FS 1.x UPN"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Role"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Surname"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="PPID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Name ID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authentication time stamp"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authentication method"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only group SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only primary SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Deny only primary group SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Group SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Primary group SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Primary SID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Windows account name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Is Registered User"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Device Identifier"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/registrationid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Device Registration Identifier"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/displayname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Device Registration DisplayName"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/ostype" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Device OS type"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/osversion" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Device OS Version"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/devicecontext/claims/ismanaged" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Is Managed Device"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Forwarded Client IP"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Client Application"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-user-agent" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Client User Agent"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-ip" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Client IP"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Endpoint Path"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-proxy" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Proxy"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/relyingpartytrustid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Application Identifier"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/applicationpolicy" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Application policies"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/authoritykeyidentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authority Key Identifier"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/basicconstraints" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Basic Constraint"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/eku" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Enhanced Key Usage"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuer" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Issuer"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/issuername" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Issuer Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/keyusage" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Key Usage"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/notafter" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Not After"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/notbefore" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Not Before"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatepolicy" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Certificate Policies"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/rsa" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Public Key"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/rawdata" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Certificate Raw Data"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/san" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Subject Alternative Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/serialnumber" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Serial Number"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/signaturealgorithm" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Signature Algorithm"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/subject" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Subject"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/subjectkeyidentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Subject Key Identifier"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Subject Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplateinformation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="V2 Template Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplatename" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="V1 Template Name"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/thumbprint" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Thumbprint"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/12/certificatecontext/field/x509version" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="X.509 Version"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Inside Corporate Network"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Password Expiration Time"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Password Expiration Days"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2012/01/passwordchangeurl" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Update Password URL"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/claims/authnmethodsreferences" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Authentication Methods References"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/2012/01/requestcontext/claims/client-request-id" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Client Request ID"/>
+    <Attribute xmlns="urn:oasis:names:tc:SAML:2.0:assertion" Name="http://schemas.microsoft.com/ws/2013/11/alternateloginid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="Alternate Login ID"/>
+  </IDPSSODescriptor>
+  <ContactPerson contactType="support">
+    <EmailAddress/>
+    <TelephoneNumber/>
+  </ContactPerson>
+</EntityDescriptor>

--- a/src/test/resources/metadata/sveleg-fedtest-badschema.xml
+++ b/src/test/resources/metadata/sveleg-fedtest-badschema.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_19893022" cacheDuration="PT10M0.000S" validUntil="2030-05-04T21:17:39.086Z">
   <md:EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/src/test/resources/metadata/sveleg-fedtest-complex.xml
+++ b/src/test/resources/metadata/sveleg-fedtest-complex.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_19893022" cacheDuration="PT10M0.000S">
   <md:EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/src/test/resources/metadata/sveleg-fedtest-part1.xml
+++ b/src/test/resources/metadata/sveleg-fedtest-part1.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_part1" cacheDuration="PT10M0.000S" validUntil="2030-05-04T21:17:39.086Z">
   <md:EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/src/test/resources/metadata/sveleg-fedtest-part2.xml
+++ b/src/test/resources/metadata/sveleg-fedtest-part2.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_part2" cacheDuration="PT10M0.000S" validUntil="2030-05-04T21:17:39.086Z">
   <md:EntityDescriptor xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" entityID="http://sts-pt.transportstyrelsen.se/adfs/services/trust/"
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">

--- a/src/test/resources/metadata/sveleg-fedtest-part3.xml
+++ b/src/test/resources/metadata/sveleg-fedtest-part3.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_part3" cacheDuration="PT10M0.000S" validUntil="2030-05-04T21:17:39.086Z">
   <md:EntityDescriptor xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdext="urn:oasis:names:tc:SAML:metadata:extension" xmlns:ns10="urn:oasis:names:tc:SAML:profiles:v1metadata"

--- a/src/test/resources/metadata/sveleg-fedtest.xml
+++ b/src/test/resources/metadata/sveleg-fedtest.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="metadata_19893022" cacheDuration="PT10M0.000S" validUntil="2030-05-04T21:17:39.086Z">
   <md:EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/src/test/resources/signed/signed-baddigest-response.xml
+++ b/src/test/resources/signed/signed-baddigest-response.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <saml2p:Response Destination="https://localhost:8443/svelegtest-sp/saml2/post/3" ID="_87734b496b7a17965c678b6735fd12fe" InResponseTo="_2y6q15DKxcGX3HFJXadjcKGQ7Zk5Xf60RzJmB1l2" IssueInstant="2018-03-19T16:28:41.783Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.svelegtest.se/idp</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
 <ds:SignedInfo>
 <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>

--- a/src/test/resources/signed/signed-response.xml
+++ b/src/test/resources/signed/signed-response.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016-2024 Sweden Connect
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <saml2p:Response Destination="https://localhost:8443/svelegtest-sp/saml2/post/3" ID="_87734b496b7a17965c678b6735fd12fe" InResponseTo="_2y6q15DKxcGX3HFJXadjcKGQ7Zk5Xf60RzJmB1l2" IssueInstant="2018-03-19T16:28:41.783Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.svelegtest.se/idp</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
 <ds:SignedInfo>
 <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2016-2024 Sweden Connect
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 org.slf4j.simpleLogger.logFile=System.out
 org.slf4j.simpleLogger.defaultLogLevel=INFO
 org.slf4j.simpleLogger.log.se.swedenconnect.opensaml=TRACE
+org.slf4j.simpleLogger.log.org.eclipse.jetty.server=DEBUG

--- a/src/test/resources/version.properties
+++ b/src/test/resources/version.properties
@@ -1,1 +1,16 @@
+#
+# Copyright 2016-2024 Sweden Connect
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 library.version=${project.version}


### PR DESCRIPTION
The metadata providers fail when we stumble upon AD metadata containing funny RoleDescriptors. We introduced a work-around where we only save SSO descriptors.

Closes #76  